### PR TITLE
[DAD-385] feat: API Response 템플릿 만들기

### DIFF
--- a/src/main/java/com/forever/dadamda/dto/ApiResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/ApiResponse.java
@@ -9,8 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ApiResponse<T> {
 
-    public static final ApiResponse<String> OK = success("OK");
-
     private String resultCode;
 
     private String message;
@@ -19,6 +17,10 @@ public class ApiResponse<T> {
 
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>("", "", data);
+    }
+
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>("OK000", "OK", null);
     }
 
     public static <T> ApiResponse<T> error(ErrorCode errorCode) {

--- a/src/main/java/com/forever/dadamda/dto/ApiResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.forever.dadamda.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    public static final ApiResponse<String> OK = success("OK");
+
+    private String resultCode;
+
+    private String message;
+
+    private T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("", "", data);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(errorCode.getCode(), message, null);
+    }
+}

--- a/src/main/java/com/forever/dadamda/dto/ErrorCode.java
+++ b/src/main/java/com/forever/dadamda/dto/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.forever.dadamda.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    /**
+     * 400 Bad Request (잘못된 요청)
+     */
+    INVALID("BR000", "잘못된 요청입니다."),
+    INVALID_AUTH_TOKEN("BR001", "만료된 엑세스 토큰입니다."),
+
+    /**
+     * 404 Not Found (존재하지 않는 리소스)
+     */
+    NOT_EXISTS("NF000", "존재하지 않습니다."),
+    NOT_EXISTS_SCRAP("NF001", "존재하지 않는 스크랩입니다."),
+
+    /**
+     * 500 Internal Server Exception (서버 내부 에러)
+     */
+    INTERNAL_SERVER("IS000", "서버 내부 에러가 발생했습니다."),
+    ;
+
+    private final String code;
+    private final String message;
+
+    ErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/forever/dadamda/exception/GeneralException.java
+++ b/src/main/java/com/forever/dadamda/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package com.forever.dadamda.exception;
+
+import com.forever.dadamda.dto.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public abstract class GeneralException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected GeneralException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/forever/dadamda/exception/InternalServerException.java
+++ b/src/main/java/com/forever/dadamda/exception/InternalServerException.java
@@ -1,0 +1,14 @@
+package com.forever.dadamda.exception;
+
+import com.forever.dadamda.dto.ErrorCode;
+
+public class InternalServerException extends GeneralException {
+
+    public InternalServerException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public InternalServerException(String message) {
+        super(message, ErrorCode.INTERNAL_SERVER);
+    }
+}

--- a/src/main/java/com/forever/dadamda/exception/InvalidException.java
+++ b/src/main/java/com/forever/dadamda/exception/InvalidException.java
@@ -1,0 +1,14 @@
+package com.forever.dadamda.exception;
+
+import com.forever.dadamda.dto.ErrorCode;
+
+public class InvalidException extends GeneralException {
+
+    public InvalidException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public InvalidException(String message) {
+        super(message, ErrorCode.INVALID);
+    }
+}

--- a/src/main/java/com/forever/dadamda/exception/NotFoundException.java
+++ b/src/main/java/com/forever/dadamda/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package com.forever.dadamda.exception;
+
+import com.forever.dadamda.dto.ErrorCode;
+
+public class NotFoundException extends GeneralException {
+
+    public NotFoundException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public NotFoundException(String message) {
+        super(message, ErrorCode.NOT_EXISTS);
+    }
+}

--- a/src/main/java/com/forever/dadamda/exception/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/forever/dadamda/exception/advice/ControllerExceptionAdvice.java
@@ -1,0 +1,43 @@
+package com.forever.dadamda.exception.advice;
+
+import com.forever.dadamda.dto.ApiResponse;
+import com.forever.dadamda.exception.InternalServerException;
+import com.forever.dadamda.exception.InvalidException;
+import com.forever.dadamda.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class ControllerExceptionAdvice {
+
+    /**
+     * 400 Bad Request (잘못된 요청)
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(InvalidException.class)
+    private ApiResponse<Object> handleBadRequest(InvalidException e) {
+        return ApiResponse.error(e.getErrorCode());
+    }
+
+    /**
+     * 404 Not Found (존재하지 않는 리소스)
+     */
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    private ApiResponse<Object> handleNotFound(NotFoundException e) {
+        return ApiResponse.error(e.getErrorCode());
+    }
+
+    /**
+     * 500 Internal Server Exception (서버 내부 에러)
+     */
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(InternalServerException.class)
+    private ApiResponse<Object> handleInternalServerException(InternalServerException e) {
+        return ApiResponse.error(e.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 개요
- DAD-385
- API Response 템플릿 구현

## 작업사항
- 400 Bad Request (잘못된 요청) 예외 관련 응답 처리
- 500 Internal Server Exception (서버 내부 에러) 예외 관련 응답 처리
- 404 Not Found (존재하지 않는 리소스) 예외 관련 응답 처리