### PR TITLE
[DAD-386] feat: 유저, 아이템, 메모 엔티티 생성

### DIFF
--- a/src/main/java/com/forever/dadamda/config/SecurityConfig.java
+++ b/src/main/java/com/forever/dadamda/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.forever.dadamda.config;
 
-import com.forever.dadamda.entity.Role;
+import com.forever.dadamda.entity.user.Role;
 import com.forever.dadamda.filter.JwtAuthFilter;
 import com.forever.dadamda.handler.OAuth2SuccessHandler;
 import com.forever.dadamda.service.CustomOAuth2UserService;
@@ -33,7 +33,7 @@ public class SecurityConfig {
                  .and()
                     .authorizeRequests()
                         .antMatchers("/h2-console/**", "/actuator/**",
-                                "/api-docs/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                "/","/api-docs/**", "/swagger-ui/**").permitAll()
                         .antMatchers("/api/v1/**").hasRole(Role.USER.name())
                         .anyRequest().authenticated()
                  .and()

--- a/src/main/java/com/forever/dadamda/dto/OAuthAttributes.java
+++ b/src/main/java/com/forever/dadamda/dto/OAuthAttributes.java
@@ -1,7 +1,8 @@
 package com.forever.dadamda.dto;
 
-import com.forever.dadamda.entity.Role;
-import com.forever.dadamda.entity.User;
+import com.forever.dadamda.entity.user.Provider;
+import com.forever.dadamda.entity.user.Role;
+import com.forever.dadamda.entity.user.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,18 +15,20 @@ public class OAuthAttributes {
     private String nameAttributeKey;
     private String name;
     private String email;
-    private String pictureURL;
+    private String profileUrl;
+    private Provider provider;
 
     @Builder
     public OAuthAttributes(Map<String, Object> attributes,
             String nameAttributeKey,
-            String name, String email, String pictureURL) {
+            String name, String email, String profileUrl, Provider provider) {
 
         this.attributes = attributes;
         this.nameAttributeKey = nameAttributeKey;
         this.name = name;
         this.email = email;
-        this.pictureURL = pictureURL;
+        this.profileUrl = profileUrl;
+        this.provider = provider;
     }
 
     public static OAuthAttributes of(String registrationId,
@@ -41,9 +44,10 @@ public class OAuthAttributes {
         return OAuthAttributes.builder()
                 .name((String) attributes.get("name"))
                 .email((String) attributes.get("email"))
-                .pictureURL((String) attributes.get("picture"))
+                .profileUrl((String) attributes.get("picture"))
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
+                .provider(Provider.GOOGLE)
                 .build();
     }
 
@@ -51,6 +55,8 @@ public class OAuthAttributes {
         return User.builder()
                 .name(name)
                 .email(email)
+                .profileUrl(profileUrl)
+                .provider(provider)
                 .role(Role.USER)
                 .build();
     }

--- a/src/main/java/com/forever/dadamda/entity/BaseTimeEntity.java
+++ b/src/main/java/com/forever/dadamda/entity/BaseTimeEntity.java
@@ -19,4 +19,6 @@ public class BaseTimeEntity {
 
     @LastModifiedDate
     private LocalDateTime modifiedDate;
+
+    private LocalDateTime deletedDate;
 }

--- a/src/main/java/com/forever/dadamda/entity/Memo.java
+++ b/src/main/java/com/forever/dadamda/entity/Memo.java
@@ -1,0 +1,29 @@
+package com.forever.dadamda.entity;
+
+import com.forever.dadamda.entity.item.Item;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Memo {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "memo_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(length = 1000)
+    private String memo;
+
+    @Column(length = 2083)
+    private String memoImageUrl;
+}

--- a/src/main/java/com/forever/dadamda/entity/item/Article.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Article.java
@@ -1,0 +1,22 @@
+package com.forever.dadamda.entity.item;
+
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+public class Article extends Item {
+
+    private String author;
+
+    @Column(length = 2083)
+    private String authorImageUrl;
+
+    @Column(length = 100)
+    private String siteName;
+
+    private Date publishedDate;
+
+    @Column(length = 100)
+    private String blogName;
+}

--- a/src/main/java/com/forever/dadamda/entity/item/Article.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Article.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 @Entity
 public class Article extends Item {
 
+    @Column(length = 100)
     private String author;
 
     @Column(length = 2083)

--- a/src/main/java/com/forever/dadamda/entity/item/Article.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Article.java
@@ -1,6 +1,6 @@
 package com.forever.dadamda.entity.item;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
@@ -16,7 +16,7 @@ public class Article extends Item {
     @Column(length = 100)
     private String siteName;
 
-    private Date publishedDate;
+    private LocalDateTime publishedDate;
 
     @Column(length = 100)
     private String blogName;

--- a/src/main/java/com/forever/dadamda/entity/item/Item.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Item.java
@@ -1,0 +1,50 @@
+package com.forever.dadamda.entity.item;
+
+import com.forever.dadamda.entity.BaseTimeEntity;
+import com.forever.dadamda.entity.Memo;
+import com.forever.dadamda.entity.user.User;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "d_type")
+public class Item extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "item")
+    private List<Memo> memoList = new ArrayList<>();
+
+    @Column(length = 2083, nullable = false)
+    private String pageUrl;
+
+    @Column(length = 200)
+    private String title;
+
+    @Column(length = 2083)
+    private String thumnailUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+}

--- a/src/main/java/com/forever/dadamda/entity/item/Product.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Product.java
@@ -1,0 +1,12 @@
+package com.forever.dadamda.entity.item;
+
+import javax.persistence.Column;
+
+public class Product extends Item {
+
+    @Column(length = 100)
+    private String price;
+
+    @Column(length = 100)
+    private String siteName;
+}

--- a/src/main/java/com/forever/dadamda/entity/item/Product.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Product.java
@@ -1,7 +1,9 @@
 package com.forever.dadamda.entity.item;
 
 import javax.persistence.Column;
+import javax.persistence.Entity;
 
+@Entity
 public class Product extends Item {
 
     @Column(length = 100)

--- a/src/main/java/com/forever/dadamda/entity/item/Video.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Video.java
@@ -1,0 +1,30 @@
+package com.forever.dadamda.entity.item;
+
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+public class Video extends Item {
+
+    @Column(length = 2083)
+    private String embedUrl;
+
+    @Column(length = 100)
+    private String channelName;
+
+    @Column(length = 2083)
+    private String channelImageUrl;
+
+    private Long watchedCnt;
+
+    private Long playTime;
+
+    private Date publishedDate;
+
+    @Column(length = 100)
+    private String siteName;
+
+    @Column(length = 100)
+    private String genre;
+}

--- a/src/main/java/com/forever/dadamda/entity/item/Video.java
+++ b/src/main/java/com/forever/dadamda/entity/item/Video.java
@@ -1,6 +1,6 @@
 package com.forever.dadamda.entity.item;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
@@ -20,7 +20,7 @@ public class Video extends Item {
 
     private Long playTime;
 
-    private Date publishedDate;
+    private LocalDateTime publishedDate;
 
     @Column(length = 100)
     private String siteName;

--- a/src/main/java/com/forever/dadamda/entity/user/Provider.java
+++ b/src/main/java/com/forever/dadamda/entity/user/Provider.java
@@ -1,0 +1,5 @@
+package com.forever.dadamda.entity.user;
+
+public enum Provider {
+    GOOGLE, NAVER, KAKAO
+}

--- a/src/main/java/com/forever/dadamda/entity/user/Role.java
+++ b/src/main/java/com/forever/dadamda/entity/user/Role.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.entity;
+package com.forever.dadamda.entity.user;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -1,5 +1,9 @@
-package com.forever.dadamda.entity;
+package com.forever.dadamda.entity.user;
 
+import com.forever.dadamda.entity.BaseTimeEntity;
+import com.forever.dadamda.entity.item.Item;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,19 +26,26 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
+    private String profileUrl;
+
+    private Provider provider;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
 
     @Builder
-    public User(String name, String email, Role role) {
+    public User(String name, String email, String profileUrl, Provider provider, Role role) {
         this.name = name;
         this.email = email;
+        this.profileUrl = profileUrl;
+        this.provider = provider;
         this.role = role;
     }
 
-    public User update(String name) {
+    public User update(String name, String profileUrl) {
         this.name = name;
+        this.profileUrl = profileUrl;
         return this;
     }
 

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -23,15 +23,20 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user")
     private List<Item> itemList = new ArrayList<>();
 
-    @Column(nullable = false)
+    @Column(length = 100, nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(length = 320, nullable = false)
     private String email;
 
+    @Column(length = 2083, nullable = false)
     private String profileUrl;
 
+    @Column(nullable = false)
     private Provider provider;
+
+    @Column(length = 36, nullable = false)
+    private String uuid;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -17,8 +17,11 @@ public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "USER_ID")
+    @Column(name = "user_id")
     private Long id;
+
+    @OneToMany(mappedBy = "user")
+    private List<Item> itemList = new ArrayList<>();
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/forever/dadamda/repository/UserRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package com.forever.dadamda.repository;
 
-import com.forever.dadamda.entity.User;
+import com.forever.dadamda.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/forever/dadamda/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/forever/dadamda/service/CustomOAuth2UserService.java
@@ -1,7 +1,7 @@
 package com.forever.dadamda.service;
 
 import com.forever.dadamda.dto.OAuthAttributes;
-import com.forever.dadamda.entity.User;
+import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -44,7 +44,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private User saveOrUpdate(OAuthAttributes attributes) {
 
         User user = userRepository.findByEmail(attributes.getEmail())
-                .map(entity -> entity.update(attributes.getName()))
+                .map(entity -> entity.update(attributes.getName(), attributes.getProfileUrl()))
                 .orElse(attributes.toEntity());
 
         return userRepository.save(user);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,32 +4,9 @@ spring:
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
----
-# 개발 환경 설정 파일
-spring:
-  config:
-    activate:
-      on-profile: dev
-
-  jpa:
-    show_sql: true
-    hibernate:
-      ddl-auto: create-drop
----
-# 배포 환경 설정 파일
-spring:
-  config:
-    activate:
-      on-profile: prod
-
-  jpa:
-    show_sql: true
-    hibernate:
-      ddl-auto: update
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui.html
     groups-order: DESC
     operationsSorter: method
     disable-swagger-default-url: true
@@ -41,3 +18,29 @@ springdoc:
   default-produces-media-type: application/json
   paths-to-match:
     - /api/v1/**
+
+---
+# 개발 환경 설정 파일
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  jpa:
+    show_sql: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+---
+# 배포 환경 설정 파일
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  jpa:
+    show_sql: true
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
## 개요
- DAD-386

## 작업사항
- 유저 엔티티에 프로필 이미지 url, 소셜 로그인 제공자 column 추가
- 유저 엔티티에 아이템 매핑 정보 추가
- 아이템(영상, 상품, 아티클) 엔티티 추가
- 메모 엔티티 추가
- swagger 설정 위치 변경 및 sql 관련 설정 변경
