### PR TITLE
[DAD-389] feat: 스크랩 삭제 API 구현

### DIFF
--- a/src/main/java/com/forever/dadamda/config/SecurityConfig.java
+++ b/src/main/java/com/forever/dadamda/config/SecurityConfig.java
@@ -3,7 +3,7 @@ package com.forever.dadamda.config;
 import com.forever.dadamda.entity.user.Role;
 import com.forever.dadamda.filter.JwtAuthFilter;
 import com.forever.dadamda.handler.OAuth2SuccessHandler;
-import com.forever.dadamda.service.CustomOAuth2UserService;
+import com.forever.dadamda.service.user.CustomOAuth2UserService;
 import com.forever.dadamda.service.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/forever/dadamda/config/SwaggerConfig.java
+++ b/src/main/java/com/forever/dadamda/config/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
 
     @Bean
     public GroupedOpenApi chatOpenApi() {
-        String[] paths = {"/api/v1/**"};
+        String[] paths = {"/v1/**"};
 
         return GroupedOpenApi.builder()
                 .group("다담다 API v1")

--- a/src/main/java/com/forever/dadamda/controller/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/ScrapController.java
@@ -19,7 +19,7 @@ public class ScrapController {
     private final ScrapService scrapService;
 
     @Operation(summary = "스크랩 추가", description = "'크롬 익스텐션'과 '+ 버튼'을 통해서 스크랩을 추가할 수 있습니다.")
-    @PostMapping("/v1/scraps") //uri 구조 변경시, 수정해야 함.
+    @PostMapping("/v1/scraps")
     public ApiResponse<CreateScrapResponse> addScraps(
             @Valid @RequestBody CreateScrapRequest createScrapRequest) throws ParseException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -28,5 +28,18 @@ public class ScrapController {
         CreateScrapResponse createScrapResponse = scrapService.createScraps(email,
                 createScrapRequest.getPageUrl());
         return ApiResponse.success(createScrapResponse);
+    }
+
+    @Operation(summary = "스크랩 삭제", description = "한개의 스크랩을 삭제할 수 있습니다.")
+    @DeleteMapping("/v1/scraps/{scrapId}")
+    public ApiResponse<String> deleteScraps(
+            @Valid @PathVariable("scrapId") Long scrapId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String email = authentication.getName();
+
+        scrapService.deleteScraps(email, scrapId);
+
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/forever/dadamda/entity/BaseTimeEntity.java
+++ b/src/main/java/com/forever/dadamda/entity/BaseTimeEntity.java
@@ -1,5 +1,6 @@
 package com.forever.dadamda.entity;
 
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -21,4 +22,8 @@ public class BaseTimeEntity {
     private LocalDateTime modifiedDate;
 
     private LocalDateTime deletedDate;
+
+    public void updateDeletedDate(@NotNull LocalDateTime deletedDate){
+        this.deletedDate = deletedDate;
+    }
 }

--- a/src/main/java/com/forever/dadamda/repository/ScrapRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/ScrapRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     Optional<Scrap> findByPageUrlAndUserAndDeletedDateIsNull(String pageUrl, User user);
+    Optional<Scrap> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 }

--- a/src/main/java/com/forever/dadamda/service/user/CustomOAuth2UserService.java
+++ b/src/main/java/com/forever/dadamda/service/user/CustomOAuth2UserService.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.service;
+package com.forever.dadamda.service.user;
 
 import com.forever.dadamda.dto.user.OAuthAttributes;
 import com.forever.dadamda.entity.user.User;

--- a/src/main/java/com/forever/dadamda/service/user/UserService.java
+++ b/src/main/java/com/forever/dadamda/service/user/UserService.java
@@ -1,0 +1,23 @@
+package com.forever.dadamda.service.user;
+
+import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.NotFoundException;
+import com.forever.dadamda.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User validateUser(String email) {
+        return userRepository.findByEmail(email).orElseThrow(
+                () -> new NotFoundException(ErrorCode.NOT_EXISTS_MEMBER)
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
   paths-to-match:
-    - /api/v1/**
+    - /v1/**
 
 ---
 # 개발 환경 설정 파일


### PR DESCRIPTION
## 개요
- DAD-389
- 스크랩 삭제 API 구현

## 작업사항
- 스크랩 삭제 API Controller, Service, Repository 구현
- URI 변경에 따른 스웨거 설정 변경
- userRepository.findByEmail 공통 로직을 서비스 로직으로 분리

## 변경로직(Optional)
- user Service 폴더 분리