### PR TITLE
[DAD-474] refactor: API 응답에 DB 날짜 관련 정보 삭제 및 전체 조회가 아닌 조회 API에 Dtype 삭제

### DIFF
--- a/src/main/java/com/forever/dadamda/dto/scrap/GetArticleResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetArticleResponse.java
@@ -16,10 +16,6 @@ public class GetArticleResponse {
 
     // 공통 부분
     private Long scrapId;
-    private String dType;
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
-    private LocalDateTime deletedDate;
     private String description;
     private String pageUrl;
     private String siteName;
@@ -35,20 +31,15 @@ public class GetArticleResponse {
     public static GetArticleResponse of(Article article) {
         return new GetArticleResponseBuilder()
                 .scrapId(article.getId())
-                .createdDate(article.getCreatedDate())
-                .modifiedDate(article.getModifiedDate())
-                .deletedDate(article.getDeletedDate())
                 .description(article.getDescription())
                 .pageUrl(article.getPageUrl())
                 .siteName(article.getSiteName())
                 .thumbnailUrl(article.getThumbnailUrl())
-                .deletedDate(article.getDeletedDate())
                 .title(article.getTitle())
                 .author(article.getAuthor())
                 .authorImageUrl(article.getAuthorImageUrl())
                 .blogName(article.getBlogName())
                 .publishedDate(article.getPublishedDate())
-                .dType("article")
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetOtherResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetOtherResponse.java
@@ -16,10 +16,6 @@ public class GetOtherResponse {
 
     // 공통 부분
     private Long scrapId;
-    private String dType;
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
-    private LocalDateTime deletedDate;
     private String description;
     private String pageUrl;
     private String siteName;
@@ -29,16 +25,11 @@ public class GetOtherResponse {
     public static GetOtherResponse of(Other other) {
         return new GetOtherResponseBuilder()
                 .scrapId(other.getId())
-                .createdDate(other.getCreatedDate())
-                .modifiedDate(other.getModifiedDate())
-                .deletedDate(other.getDeletedDate())
                 .description(other.getDescription())
                 .pageUrl(other.getPageUrl())
                 .siteName(other.getSiteName())
                 .thumbnailUrl(other.getThumbnailUrl())
-                .deletedDate(other.getDeletedDate())
                 .title(other.getTitle())
-                .dType("other")
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetProductResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetProductResponse.java
@@ -16,10 +16,6 @@ public class GetProductResponse {
 
     // 공통 부분
     private Long scrapId;
-    private String dType;
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
-    private LocalDateTime deletedDate;
     private String description;
     private String pageUrl;
     private String siteName;
@@ -32,17 +28,12 @@ public class GetProductResponse {
     public static GetProductResponse of(Product product) {
         return new GetProductResponseBuilder()
                 .scrapId(product.getId())
-                .createdDate(product.getCreatedDate())
-                .modifiedDate(product.getModifiedDate())
-                .deletedDate(product.getDeletedDate())
                 .description(product.getDescription())
                 .pageUrl(product.getPageUrl())
                 .siteName(product.getSiteName())
                 .thumbnailUrl(product.getThumbnailUrl())
-                .deletedDate(product.getDeletedDate())
                 .title(product.getTitle())
                 .price(product.getPrice())
-                .dType("product")
                 .build();
     }
 

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetScrapResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetScrapResponse.java
@@ -20,9 +20,6 @@ public class GetScrapResponse {
     // 공통 부분
     private Long scrapId;
     private String dType;
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
-    private LocalDateTime deletedDate;
     private String description;
     private String pageUrl;
     private String siteName;
@@ -49,14 +46,10 @@ public class GetScrapResponse {
     public static GetScrapResponse of(Scrap scrap) {
         GetScrapResponseBuilder getScrapResponse = new GetScrapResponseBuilder()
                 .scrapId(scrap.getId())
-                .createdDate(scrap.getCreatedDate())
-                .modifiedDate(scrap.getModifiedDate())
-                .deletedDate(scrap.getDeletedDate())
                 .description(scrap.getDescription())
                 .pageUrl(scrap.getPageUrl())
                 .siteName(scrap.getSiteName())
                 .thumbnailUrl(scrap.getThumbnailUrl())
-                .deletedDate(scrap.getDeletedDate())
                 .title(scrap.getTitle());
 
         if (scrap instanceof Article) {

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetVideoResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetVideoResponse.java
@@ -16,10 +16,6 @@ public class GetVideoResponse {
 
     // 공통 부분
     private Long scrapId;
-    private String dType;
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
-    private LocalDateTime deletedDate;
     private String description;
     private String pageUrl;
     private String siteName;
@@ -37,13 +33,10 @@ public class GetVideoResponse {
     public static GetVideoResponse of(Video video) {
         return new GetVideoResponseBuilder()
                 .scrapId(video.getId())
-                .createdDate(video.getCreatedDate())
-                .modifiedDate(video.getModifiedDate())
                 .description(video.getDescription())
                 .pageUrl(video.getPageUrl())
                 .siteName(video.getSiteName())
                 .thumbnailUrl(video.getThumbnailUrl())
-                .deletedDate(video.getDeletedDate())
                 .title(video.getTitle())
                 .channelImageUrl(video.getChannelImageUrl())
                 .channelName(video.getChannelName())
@@ -51,7 +44,6 @@ public class GetVideoResponse {
                 .genre(video.getGenre())
                 .playTime(video.getPlayTime())
                 .watchedCnt(video.getWatchedCnt())
-                .dType("video")
                 .build();
     }
 }


### PR DESCRIPTION
## 개요
- DAD-474

## 작업사항
- 응답 : created_at,modifiedDate, deletedDate 삭제
- 전체 조회가 아닌 경우 dtype 삭제