### PR TITLE
[DAD-475] 스크랩 조회 시 메모도 함께 조회되도록 변경

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/MemoController.java
+++ b/src/main/java/com/forever/dadamda/controller/MemoController.java
@@ -1,0 +1,32 @@
+package com.forever.dadamda.controller;
+
+import com.forever.dadamda.dto.ApiResponse;
+import com.forever.dadamda.dto.scrap.CreateHighlightRequest;
+import com.forever.dadamda.dto.scrap.CreateHighlightResponse;
+import com.forever.dadamda.dto.scrap.CreateMemoRequest;
+import com.forever.dadamda.service.MemoService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class MemoController {
+
+    private final MemoService memoService;
+
+    @Operation(summary = "메모 추가", description = "크롬 익스텐션을 사용하여, 하이라이트할 문자들과 사진을 추가할 수 있습니다.")
+    @PostMapping("/v1/scraps/memo")
+    public ApiResponse addMemo(@Valid @RequestBody CreateMemoRequest createMemoRequest,
+            Authentication authentication) {
+        String email = authentication.getName();
+        memoService.createMemo(email, createMemoRequest);
+        return ApiResponse.success();
+    }
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/CreateMemoRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/CreateMemoRequest.java
@@ -1,0 +1,19 @@
+package com.forever.dadamda.dto.scrap;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Size;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateMemoRequest {
+
+    private Long scrapId;
+
+    @Size(max = 1000, message = "최대 1000자까지 선택할 수 있습니다.")
+    private String memoText;
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetArticleResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetArticleResponse.java
@@ -2,6 +2,8 @@ package com.forever.dadamda.dto.scrap;
 
 import com.forever.dadamda.entity.scrap.Article;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +23,7 @@ public class GetArticleResponse {
     private String siteName;
     private String thumbnailUrl;
     private String title;
+    private List<GetMemoResponse> memoList;
 
     // Article 부분
     private String author;
@@ -40,6 +43,7 @@ public class GetArticleResponse {
                 .authorImageUrl(article.getAuthorImageUrl())
                 .blogName(article.getBlogName())
                 .publishedDate(article.getPublishedDate())
+                .memoList(article.getMemoList().stream().map(GetMemoResponse::of).collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetMemoResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetMemoResponse.java
@@ -1,0 +1,25 @@
+package com.forever.dadamda.dto.scrap;
+
+import com.forever.dadamda.entity.Memo;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetMemoResponse {
+
+    private Long memoId;
+    private String memo;
+
+    public static GetMemoResponse of(Memo memo) {
+        return GetMemoResponse.builder()
+                .memoId(memo.getId())
+                .memo(memo.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetOtherResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetOtherResponse.java
@@ -2,6 +2,8 @@ package com.forever.dadamda.dto.scrap;
 
 import com.forever.dadamda.entity.scrap.Other;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +23,7 @@ public class GetOtherResponse {
     private String siteName;
     private String thumbnailUrl;
     private String title;
+    private List<GetMemoResponse> memoList;
 
     public static GetOtherResponse of(Other other) {
         return new GetOtherResponseBuilder()
@@ -30,6 +33,8 @@ public class GetOtherResponse {
                 .siteName(other.getSiteName())
                 .thumbnailUrl(other.getThumbnailUrl())
                 .title(other.getTitle())
+                .memoList(other.getMemoList().stream().map(GetMemoResponse::of).collect(
+                        Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetProductResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetProductResponse.java
@@ -2,6 +2,8 @@ package com.forever.dadamda.dto.scrap;
 
 import com.forever.dadamda.entity.scrap.Product;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +23,7 @@ public class GetProductResponse {
     private String siteName;
     private String thumbnailUrl;
     private String title;
+    private List<GetMemoResponse> memoList;
 
     // Product 부분
     private String price;
@@ -34,6 +37,8 @@ public class GetProductResponse {
                 .thumbnailUrl(product.getThumbnailUrl())
                 .title(product.getTitle())
                 .price(product.getPrice())
+                .memoList(product.getMemoList().stream().map(GetMemoResponse::of).collect(
+                        Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetScrapResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetScrapResponse.java
@@ -5,6 +5,8 @@ import com.forever.dadamda.entity.scrap.Product;
 import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.entity.scrap.Video;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,6 +27,7 @@ public class GetScrapResponse {
     private String siteName;
     private String thumbnailUrl;
     private String title;
+    private List<GetMemoResponse> memoList;
 
     // Article 부분
     private String author;
@@ -50,7 +53,8 @@ public class GetScrapResponse {
                 .pageUrl(scrap.getPageUrl())
                 .siteName(scrap.getSiteName())
                 .thumbnailUrl(scrap.getThumbnailUrl())
-                .title(scrap.getTitle());
+                .title(scrap.getTitle())
+                .memoList(scrap.getMemoList().stream().map(GetMemoResponse::of).collect(Collectors.toList()));
 
         if (scrap instanceof Article) {
             Article article = (Article) scrap;

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetVideoResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetVideoResponse.java
@@ -2,6 +2,8 @@ package com.forever.dadamda.dto.scrap;
 
 import com.forever.dadamda.entity.scrap.Video;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +23,7 @@ public class GetVideoResponse {
     private String siteName;
     private String thumbnailUrl;
     private String title;
+    private List<GetMemoResponse> memoList;
 
     // Video 부분
     private String channelImageUrl;
@@ -44,6 +47,8 @@ public class GetVideoResponse {
                 .genre(video.getGenre())
                 .playTime(video.getPlayTime())
                 .watchedCnt(video.getWatchedCnt())
+                .memoList(video.getMemoList().stream().map(GetMemoResponse::of).collect(
+                        Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/entity/Memo.java
+++ b/src/main/java/com/forever/dadamda/entity/Memo.java
@@ -9,9 +9,11 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class Memo extends BaseTimeEntity {
 

--- a/src/main/java/com/forever/dadamda/entity/Memo.java
+++ b/src/main/java/com/forever/dadamda/entity/Memo.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
-public class Memo {
+public class Memo extends BaseTimeEntity {
 
     @Id
     @GeneratedValue

--- a/src/main/java/com/forever/dadamda/entity/scrap/Scrap.java
+++ b/src/main/java/com/forever/dadamda/entity/scrap/Scrap.java
@@ -31,7 +31,7 @@ public class Scrap extends BaseTimeEntity {
 
     @Id
     @GeneratedValue
-    @Column(name = "item_id")
+    @Column(name = "scrap_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/forever/dadamda/service/MemoService.java
+++ b/src/main/java/com/forever/dadamda/service/MemoService.java
@@ -1,10 +1,13 @@
 package com.forever.dadamda.service;
 
+import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.scrap.CreateHighlightRequest;
 import com.forever.dadamda.dto.scrap.CreateHighlightResponse;
+import com.forever.dadamda.dto.scrap.CreateMemoRequest;
 import com.forever.dadamda.entity.Memo;
 import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.MemoRepository;
 import com.forever.dadamda.repository.ScrapRepository;
 import com.forever.dadamda.service.scrap.ScrapService;
@@ -50,5 +53,21 @@ public class MemoService {
         memoRepository.save(memo);
 
         return CreateHighlightResponse.of(pageUrl);
+    }
+
+    @Transactional
+    public void createMemo(String email, CreateMemoRequest createMemoRequest) {
+        User user = userService.validateUser(email);
+
+        Scrap scrap = scrapRepository.findByIdAndUserAndDeletedDateIsNull(
+                        createMemoRequest.getScrapId(), user)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+
+        Memo memo = Memo.builder()
+                .scrap(scrap)
+                .memo(createMemoRequest.getMemoText())
+                .build();
+
+        memoRepository.save(memo);
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
@@ -68,6 +68,7 @@ public class ScrapService {
     public Scrap saveScraps(User user, String pageUrl) throws ParseException {
         //2. 람다에게 api 요청
         JSONObject crawlingResponse = webClientService.crawlingItem(pageUrl);
+
         String type = crawlingResponse.get("type").toString();
 
         //3. DB 저장
@@ -109,7 +110,8 @@ public class ScrapService {
         User user = userService.validateUser(email);
 
         Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
 
         Slice<Scrap> scrapSlice = scrapRepository.findAllByUserAndDeletedDateIsNull(
                 user, pageRequest).orElseThrow(
@@ -125,7 +127,8 @@ public class ScrapService {
         User user = userService.validateUser(email);
 
         Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
 
         Slice<Product> scrapSlice = productRepository.findAllByUserAndDeletedDateIsNull(
                 user, pageRequest).orElseThrow(
@@ -141,7 +144,8 @@ public class ScrapService {
         User user = userService.validateUser(email);
 
         Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
 
         Slice<Video> videoSlice = videoRepository.findAllByUserAndDeletedDateIsNull(
                 user, pageRequest).orElseThrow(
@@ -157,14 +161,16 @@ public class ScrapService {
         User user = userService.validateUser(email);
 
         Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
 
         Slice<Article> articleSlice = articleRepository.findAllByUserAndDeletedDateIsNull(
                 user, pageRequest).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP)
         );
 
-        Slice<GetArticleResponse> getArticlesResponseSlice = articleSlice.map(GetArticleResponse::of);
+        Slice<GetArticleResponse> getArticlesResponseSlice = articleSlice.map(
+                GetArticleResponse::of);
         return getArticlesResponseSlice;
     }
 
@@ -173,7 +179,8 @@ public class ScrapService {
         User user = userService.validateUser(email);
 
         Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
 
         Slice<Other> otherSlice = otherRepository.findAllByUserAndDeletedDateIsNull(
                 user, pageRequest).orElseThrow(


### PR DESCRIPTION
## 개요
- DAD-475

## 작업사항
- itemId -> scrapId로 변경, Memo 엔티티에 기본 시간 속성 추가
- 스크랩 조회 시 메모도 함께 조회되도록 변경