### PR TITLE
[DAD-491] fix : 크롬 익스텐션 core 허용 및 jpa show sql 설정 삭제

### DIFF
--- a/src/main/java/com/forever/dadamda/config/SecurityConfig.java
+++ b/src/main/java/com/forever/dadamda/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+        config.setAllowedOrigins(Arrays.asList("http://localhost:5173", "chrome-extension://phcggikoaniecbgkjammhcnnfcfepgnf"));
         config.setAllowedMethods(Arrays.asList("HEAD","POST","GET","DELETE","PUT", "OPTIONS"));
         config.setAllowedHeaders(Arrays.asList("*"));
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,5 @@ spring:
       on-profile: prod
 
   jpa:
-    show_sql: true
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 개요
- DAD-491

## 작업사항
- 크롬 익스텐션 core 허용 
- jpa show sql 설정 삭제
