### PR TITLE
[DAD-498] feat: 전체 스크랩 수정 API 

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/MemoController.java
+++ b/src/main/java/com/forever/dadamda/controller/MemoController.java
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
-@RestController
 @RequiredArgsConstructor
+@RestController
 public class MemoController {
 
     private final MemoService memoService;
@@ -28,5 +28,17 @@ public class MemoController {
         String email = authentication.getName();
         memoService.createMemo(email, createMemoRequest);
         return ApiResponse.success();
+    }
+
+    @Operation(summary = "하이라이트 추가", description = "크롬 익스텐션을 사용하여, 하이라이트할 문자들과 사진을 추가할 수 있습니다.")
+    @PostMapping("/v1/scraps/highlights")
+    public ApiResponse<CreateHighlightResponse> addHighlights(
+            @Valid @RequestBody CreateHighlightRequest createHighlightRequest) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        CreateHighlightResponse createHighlightResponse = memoService.createHighlights(email,
+                createHighlightRequest);
+        return ApiResponse.success(createHighlightResponse);
     }
 }

--- a/src/main/java/com/forever/dadamda/controller/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/ScrapController.java
@@ -1,8 +1,6 @@
 package com.forever.dadamda.controller;
 
 import com.forever.dadamda.dto.ApiResponse;
-import com.forever.dadamda.dto.scrap.CreateHighlightRequest;
-import com.forever.dadamda.dto.scrap.CreateHighlightResponse;
 import com.forever.dadamda.dto.scrap.CreateScrapRequest;
 import com.forever.dadamda.dto.scrap.CreateScrapResponse;
 import com.forever.dadamda.dto.scrap.GetArticleResponse;
@@ -10,6 +8,8 @@ import com.forever.dadamda.dto.scrap.GetOtherResponse;
 import com.forever.dadamda.dto.scrap.GetProductResponse;
 import com.forever.dadamda.dto.scrap.GetScrapResponse;
 import com.forever.dadamda.dto.scrap.GetVideoResponse;
+import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
+import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.service.MemoService;
 import com.forever.dadamda.service.scrap.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import net.minidev.json.parser.ParseException;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -104,16 +103,15 @@ public class ScrapController {
         return ApiResponse.success(scrapService.getOthers(email, pageable));
     }
 
+    @Operation(summary = "전체 스크랩 수정", description = "스크랩을 수정할 수 있습니다.")
+    @PatchMapping("/v1/scraps")
+    public ApiResponse<String> updateScraps(
+            @RequestBody UpdateScrapRequest updateScrapRequest,
+            Authentication authentication) {
 
-    @Operation(summary = "하이라이트 추가", description = "크롬 익스텐션을 사용하여, 하이라이트할 문자들과 사진을 추가할 수 있습니다.")
-    @PostMapping("/v1/scraps/highlights")
-    public ApiResponse<CreateHighlightResponse> addHighlights(
-            @Valid @RequestBody CreateHighlightRequest createHighlightRequest) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
-
-        CreateHighlightResponse createHighlightResponse = memoService.createHighlights(email,
-                createHighlightRequest);
-        return ApiResponse.success(createHighlightResponse);
+        Scrap scrap = scrapService.updateScraps(email, updateScrapRequest);
+        memoService.updateMemos(scrap, updateScrapRequest.getMemoList());
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/forever/dadamda/controller/UserController.java
+++ b/src/main/java/com/forever/dadamda/controller/UserController.java
@@ -30,10 +30,10 @@ public class UserController {
 
     @Operation(summary = "회원 정보 조회", description = "해당 회원의 정보를 조회할 수 있습니다.")
     @GetMapping("/v1/user")
-    public GetUserInfoResponse getUserInfo(Authentication authentication) {
+    public ApiResponse<GetUserInfoResponse> getUserInfo(Authentication authentication) {
         String email = authentication.getName();
 
-        return userService.getUserInfo(email);
+        return ApiResponse.success(userService.getUserInfo(email));
     }
 
     @Operation(summary = "회원 탈퇴", description = "해당 회원 탈퇴할 수 있습니다.")

--- a/src/main/java/com/forever/dadamda/dto/ErrorCode.java
+++ b/src/main/java/com/forever/dadamda/dto/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     NOT_EXISTS("NF000", "존재하지 않습니다."),
     NOT_EXISTS_SCRAP("NF001", "존재하지 않는 스크랩입니다."),
     NOT_EXISTS_MEMBER("NF002", "존재하지 않는 회원입니다."),
+    NOT_EXISTS_MEMO("NF003", "존재하지 않는 메모입니다."),
 
     /**
      * 500 Internal Server Exception (서버 내부 에러)

--- a/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
@@ -1,0 +1,46 @@
+package com.forever.dadamda.dto.scrap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateScrapRequest {
+    // 공통 부분
+    private Long scrapId;
+
+    @JsonProperty("dType")
+    private String dType;
+
+    private String description;
+    private String pageUrl;
+    private String siteName;
+    private String thumbnailUrl;
+    private String title;
+    private List<GetMemoResponse> memoList;
+
+    // Article 부분
+    private String author;
+    private String authorImageUrl;
+    private String blogName;
+    private LocalDateTime publishedDate;
+
+    // Product 부분
+    private String price;
+
+    // Video 부분
+    private String channelImageUrl;
+    private String channelName;
+    private String embedUrl;
+    private String genre;
+    private Long playTime;
+    private Long watchedCnt;
+}

--- a/src/main/java/com/forever/dadamda/entity/Memo.java
+++ b/src/main/java/com/forever/dadamda/entity/Memo.java
@@ -38,4 +38,9 @@ public class Memo extends BaseTimeEntity {
         this.memoText = memoText;
         this.memoImageUrl = memoImageUrl;
     }
+
+    public void update(String memoText, String memoImageUrl){
+        this.memoText = memoText;
+        this.memoImageUrl = memoImageUrl;
+    }
 }

--- a/src/main/java/com/forever/dadamda/entity/scrap/Article.java
+++ b/src/main/java/com/forever/dadamda/entity/scrap/Article.java
@@ -37,4 +37,12 @@ public class Article extends Scrap {
         this.publishedDate = publishedDate;
         this.blogName = blogName;
     }
+
+    public void updateArticle(String author, String authorImageUrl, LocalDateTime publishedDate,
+            String blogName) {
+        this.author = author;
+        this.authorImageUrl = authorImageUrl;
+        this.publishedDate = publishedDate;
+        this.blogName = blogName;
+    }
 }

--- a/src/main/java/com/forever/dadamda/entity/scrap/Product.java
+++ b/src/main/java/com/forever/dadamda/entity/scrap/Product.java
@@ -21,4 +21,8 @@ public class Product extends Scrap {
         super(user, pageUrl, title, thumbnailUrl, description, siteName);
         this.price = price;
     }
+
+    public void updateProduct(String price) {
+        this.price = price;
+    }
 }

--- a/src/main/java/com/forever/dadamda/entity/scrap/Scrap.java
+++ b/src/main/java/com/forever/dadamda/entity/scrap/Scrap.java
@@ -61,11 +61,18 @@ public class Scrap extends BaseTimeEntity {
         this.pageUrl = pageUrl;
     }
 
-    public Scrap(User user, String pageUrl, String title, String thumbnailUrl, String description, String siteName) {
+    public Scrap(User user, String pageUrl, String title, String thumbnailUrl, String description,
+            String siteName) {
         this.user = user;
         this.pageUrl = pageUrl;
         this.title = title;
         this.thumbnailUrl = thumbnailUrl;
+        this.description = description;
+        this.siteName = siteName;
+    }
+
+    public void update(String title, String description, String siteName) {
+        this.pageUrl = title;
         this.description = description;
         this.siteName = siteName;
     }

--- a/src/main/java/com/forever/dadamda/entity/scrap/Video.java
+++ b/src/main/java/com/forever/dadamda/entity/scrap/Video.java
@@ -45,4 +45,14 @@ public class Video extends Scrap {
         this.publishedDate = publishedDate;
         this.genre = genre;
     }
+
+    public void updateVideo(String channelName, String channelImageUrl, Long watchedCnt,
+            Long playTime, LocalDateTime publishedDate, String genre) {
+        this.channelName = channelName;
+        this.channelImageUrl = channelImageUrl;
+        this.watchedCnt = watchedCnt;
+        this.playTime = playTime;
+        this.publishedDate = publishedDate;
+        this.genre = genre;
+    }
 }

--- a/src/main/java/com/forever/dadamda/repository/ArticleRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/ArticleRepository.java
@@ -10,4 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     Optional<Slice<Article>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
+
+    Optional<Article> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
+
 }

--- a/src/main/java/com/forever/dadamda/repository/MemoRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/MemoRepository.java
@@ -1,8 +1,10 @@
 package com.forever.dadamda.repository;
 
 import com.forever.dadamda.entity.Memo;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
+    Optional<Memo> findByIdAndDeletedDateIsNull(Long memoId);
 }

--- a/src/main/java/com/forever/dadamda/repository/OtherRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/OtherRepository.java
@@ -8,5 +8,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OtherRepository extends JpaRepository<Other, Long> {
+
     Optional<Slice<Other>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
+
+    Optional<Other> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
+
 }

--- a/src/main/java/com/forever/dadamda/repository/ProductRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/ProductRepository.java
@@ -1,7 +1,6 @@
 package com.forever.dadamda.repository;
 
 import com.forever.dadamda.entity.scrap.Product;
-import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.entity.user.User;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Optional<Slice<Product>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
+
+    Optional<Product> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 }

--- a/src/main/java/com/forever/dadamda/repository/VideoRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/VideoRepository.java
@@ -10,4 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface VideoRepository extends JpaRepository<Video, Long> {
 
     Optional<Slice<Video>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
+
+    Optional<Video> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
+
 }

--- a/src/main/java/com/forever/dadamda/service/MemoService.java
+++ b/src/main/java/com/forever/dadamda/service/MemoService.java
@@ -4,6 +4,7 @@ import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.scrap.CreateHighlightRequest;
 import com.forever.dadamda.dto.scrap.CreateHighlightResponse;
 import com.forever.dadamda.dto.scrap.CreateMemoRequest;
+import com.forever.dadamda.dto.scrap.GetMemoResponse;
 import com.forever.dadamda.entity.Memo;
 import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.entity.user.User;
@@ -12,6 +13,8 @@ import com.forever.dadamda.repository.MemoRepository;
 import com.forever.dadamda.repository.ScrapRepository;
 import com.forever.dadamda.service.scrap.ScrapService;
 import com.forever.dadamda.service.user.UserService;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.parser.ParseException;
 import org.springframework.stereotype.Service;
@@ -69,5 +72,30 @@ public class MemoService {
                 .build();
 
         memoRepository.save(memo);
+    }
+
+    @Transactional
+    public void updateMemos(Scrap scrap, List<GetMemoResponse> getMemoResponseList) {
+        for (GetMemoResponse getMemoResponse : getMemoResponseList) {
+            if (getMemoResponse.getMemoId() > 0) {
+                Memo memo = memoRepository.findByIdAndDeletedDateIsNull(
+                        getMemoResponse.getMemoId()).orElseThrow(
+                        () -> new NotFoundException(ErrorCode.NOT_EXISTS_MEMO));
+
+                if (getMemoResponse.getMemoText() == null
+                        && getMemoResponse.getMemoImageUrl() == null) {
+                    memo.updateDeletedDate(LocalDateTime.now());
+                } else {
+                    memo.update(getMemoResponse.getMemoText(), getMemoResponse.getMemoImageUrl());
+                }
+            } else {
+                Memo memo = Memo.builder()
+                        .scrap(scrap)
+                        .memoText(getMemoResponse.getMemoText())
+                        .build();
+
+                memoRepository.save(memo);
+            }
+        }
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
@@ -1,7 +1,10 @@
 package com.forever.dadamda.service.scrap;
 
+import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Article;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONObject;
@@ -32,5 +35,21 @@ public class ArticleService {
                 .siteName(crawlingResponse.get("site_name").toString()).build();
 
         return articleRepository.save(article);
+    }
+
+    @Transactional
+    public Article updateArticle(User user, UpdateScrapRequest updateScrapRequest) {
+        Article article = articleRepository.findByIdAndUserAndDeletedDateIsNull(
+                updateScrapRequest.getScrapId(), user).orElseThrow(
+                () -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP)
+        );
+        article.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
+                updateScrapRequest.getSiteName());
+        article.updateArticle(updateScrapRequest.getAuthor(),
+                updateScrapRequest.getAuthorImageUrl(),
+                updateScrapRequest.getPublishedDate(),
+                updateScrapRequest.getBlogName());
+
+        return article;
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
@@ -1,7 +1,10 @@
 package com.forever.dadamda.service.scrap;
 
+import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Other;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.OtherRepository;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONObject;
@@ -22,5 +25,15 @@ public class OtherService {
                 .description(crawlingResponse.get("description").toString()).build();
 
         return otherRepository.save(other);
+    }
+
+    @Transactional
+    public Other updateOther(User user, UpdateScrapRequest updateScrapRequest) {
+        Other other = otherRepository.findByIdAndUserAndDeletedDateIsNull(
+                updateScrapRequest.getScrapId(), user).orElseThrow(() -> new NotFoundException(
+                ErrorCode.NOT_EXISTS_SCRAP)); //동일한 함수가 3개 이상 반복되므로 validateScrap으로 함수 따로 빼기
+        other.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
+                updateScrapRequest.getSiteName());
+        return other;
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
@@ -1,7 +1,10 @@
 package com.forever.dadamda.service.scrap;
 
+import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Product;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONObject;
@@ -23,5 +26,16 @@ public class ProductService {
                 .siteName(crawlingResponse.get("site_name").toString()).build();
 
         return productRepository.save(product);
+    }
+
+    @Transactional
+    public Product updateProduct(User user, UpdateScrapRequest updateScrapRequest) {
+        Product product = productRepository.findByIdAndUserAndDeletedDateIsNull(
+                        updateScrapRequest.getScrapId(), user)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+        product.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
+                updateScrapRequest.getSiteName());
+        product.updateProduct(updateScrapRequest.getPrice());
+        return product;
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
@@ -1,7 +1,10 @@
 package com.forever.dadamda.service.scrap;
 
+import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Video;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.VideoRepository;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONObject;
@@ -26,22 +29,32 @@ public class VideoService {
             playTime = Long.parseLong(crawlingResponse.get("play_time").toString());
         }
 
-        Video video = Video.builder()
-                .user(user)
-                .pageUrl(pageUrl)
+        Video video = Video.builder().user(user).pageUrl(pageUrl)
                 .title(crawlingResponse.get("title").toString())
                 .thumbnailUrl(crawlingResponse.get("thumbnail_url").toString())
                 .description(crawlingResponse.get("description").toString())
                 .embedUrl(crawlingResponse.get("embed_url").toString())
                 .channelName(crawlingResponse.get("channel_name").toString())
                 //.channelImageUrl(crawlingVideoResponse.get("channel_image_url").toString())
-                .watchedCnt(watchedCnt)
-                .playTime(playTime)
+                .watchedCnt(watchedCnt).playTime(playTime)
                 //.publishedDate(LocalDateTime.parse(crawlingVideoResponse.get("published_date").toString(), formatter))
                 .siteName(crawlingResponse.get("site_name").toString())
-                .genre(crawlingResponse.get("genre").toString())
-                .build();
+                .genre(crawlingResponse.get("genre").toString()).build();
 
         return videoRepository.save(video);
+    }
+
+    @Transactional
+    public Video updateVideo(User user, UpdateScrapRequest updateScrapRequest) {
+        Video video = videoRepository.findByIdAndUserAndDeletedDateIsNull(
+                        updateScrapRequest.getScrapId(), user)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+        video.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
+                updateScrapRequest.getSiteName());
+        video.updateVideo(updateScrapRequest.getChannelName(),
+                updateScrapRequest.getChannelImageUrl(), updateScrapRequest.getWatchedCnt(),
+                updateScrapRequest.getPlayTime(), updateScrapRequest.getPublishedDate(),
+                updateScrapRequest.getGenre());
+        return video;
     }
 }


### PR DESCRIPTION
## 개요
- DAD-498

## 작업사항
- 회원 정보 조회 반환 값을 ApiResponse 형태로 변경
- 하이라이트 추가 API를 스크랩 controller에서 메모 controller로 변경

- 전체 스크랩 수정 API 구현
1) 전체 스크랩 수정시, memoText와 memoImageUrl이 둘다 null이면 해당 메모 삭제
2) memoId가 양수이고 memoText와 memoImageUrl이 둘다 null이 아니면 해당 메모 업데이트
3) memoId가 음수인 경우, 새로운 메모 추가