### PR TITLE
[DAD-550] feat: 스크랩 개수 조회 API 구현

### DIFF
--- a/src/main/java/com/forever/dadamda/config/SwaggerConfig.java
+++ b/src/main/java/com/forever/dadamda/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.config;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
@@ -16,7 +17,11 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
         info = @Info(title = "다담다 API 명세서",
                 description = "신개념 컨텐츠 맞춤 스크랩 서비스, 다담다",
-                version = "v1")
+                version = "v1"),
+        servers = {
+                @Server(url = "http://localhost:8080", description = "Local Server"),
+                @Server(url = "https://api.dadamda.me:8080", description = "Product Server")
+        }
 )
 
 @RequiredArgsConstructor

--- a/src/main/java/com/forever/dadamda/controller/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/ScrapController.java
@@ -83,7 +83,7 @@ public class ScrapController {
 
         String email = authentication.getName();
 
-        return ApiResponse.success(scrapService.getProducts(email, pageable));
+        return ApiResponse.success(productService.getProducts(email, pageable));
     }
 
     @Operation(summary = "영상 조회", description = "여러개의 영상을 조회할 수 있습니다.")
@@ -93,7 +93,7 @@ public class ScrapController {
 
         String email = authentication.getName();
 
-        return ApiResponse.success(scrapService.getVideos(email, pageable));
+        return ApiResponse.success(videoService.getVideos(email, pageable));
     }
 
     @Operation(summary = "아티클 조회", description = "여러개의 아티클을 조회할 수 있습니다.")
@@ -103,7 +103,7 @@ public class ScrapController {
 
         String email = authentication.getName();
 
-        return ApiResponse.success(scrapService.getArticles(email, pageable));
+        return ApiResponse.success(articleService.getArticles(email, pageable));
     }
 
     @Operation(summary = "기타 스크랩 조회", description = "여러개의 기타 스크랩를 조회할 수 있습니다.")
@@ -113,7 +113,7 @@ public class ScrapController {
 
         String email = authentication.getName();
 
-        return ApiResponse.success(scrapService.getOthers(email, pageable));
+        return ApiResponse.success(otherService.getOthers(email, pageable));
     }
 
     @Operation(summary = "전체 스크랩 수정", description = "스크랩을 수정할 수 있습니다.")

--- a/src/main/java/com/forever/dadamda/controller/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/ScrapController.java
@@ -3,15 +3,24 @@ package com.forever.dadamda.controller;
 import com.forever.dadamda.dto.ApiResponse;
 import com.forever.dadamda.dto.scrap.CreateScrapRequest;
 import com.forever.dadamda.dto.scrap.CreateScrapResponse;
+import com.forever.dadamda.dto.scrap.GetArticleCountResponse;
 import com.forever.dadamda.dto.scrap.GetArticleResponse;
+import com.forever.dadamda.dto.scrap.GetOtherCountResponse;
 import com.forever.dadamda.dto.scrap.GetOtherResponse;
+import com.forever.dadamda.dto.scrap.GetProductCountResponse;
 import com.forever.dadamda.dto.scrap.GetProductResponse;
+import com.forever.dadamda.dto.scrap.GetScrapCountResponse;
 import com.forever.dadamda.dto.scrap.GetScrapResponse;
+import com.forever.dadamda.dto.scrap.GetVideoCountResponse;
 import com.forever.dadamda.dto.scrap.GetVideoResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.service.MemoService;
+import com.forever.dadamda.service.scrap.ArticleService;
+import com.forever.dadamda.service.scrap.OtherService;
+import com.forever.dadamda.service.scrap.ProductService;
 import com.forever.dadamda.service.scrap.ScrapService;
+import com.forever.dadamda.service.scrap.VideoService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.data.domain.Pageable;
 import javax.validation.Valid;
@@ -27,6 +36,10 @@ public class ScrapController {
 
     private final ScrapService scrapService;
     private final MemoService memoService;
+    private final ProductService productService;
+    private final VideoService videoService;
+    private final ArticleService articleService;
+    private final OtherService otherService;
 
     @Operation(summary = "스크랩 추가", description = "'크롬 익스텐션'과 '+ 버튼'을 통해서 스크랩을 추가할 수 있습니다.")
     @PostMapping("/v1/scraps")
@@ -113,5 +126,42 @@ public class ScrapController {
         Scrap scrap = scrapService.updateScraps(email, updateScrapRequest);
         memoService.updateMemos(scrap, updateScrapRequest.getMemoList());
         return ApiResponse.success();
+    }
+
+    @Operation(summary = "전체 스크랩 개수 조회", description = "전체 스크랩 개수 정보를 조회할 수 있습니다.")
+    @GetMapping("/v1/scraps/count")
+    public ApiResponse<GetScrapCountResponse> getScrapCount(Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.success(GetScrapCountResponse.of(scrapService.getScrapCount(email)));
+    }
+
+    @Operation(summary = "아티클 스크랩 개수 조회", description = "아티클 스크랩 개수 정보를 조회할 수 있습니다.")
+    @GetMapping("/v1/scraps/articles/count")
+    public ApiResponse<GetArticleCountResponse> getArticleCount(Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.success(
+                GetArticleCountResponse.of(articleService.getArticleCount(email)));
+    }
+
+    @Operation(summary = "기타 스크랩 개수 조회", description = "기타 스크랩 개수 정보를 조회할 수 있습니다.")
+    @GetMapping("/v1/scraps/others/count")
+    public ApiResponse<GetOtherCountResponse> getOtherScrap(Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.success(GetOtherCountResponse.of(otherService.getOtherCount(email)));
+    }
+
+    @Operation(summary = "상품 스크랩 개수 조회", description = "상품 스크랩 개수 정보를 조회할 수 있습니다.")
+    @GetMapping("/v1/scraps/products/count")
+    public ApiResponse<GetProductCountResponse> getProductScrap(Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.success(
+                GetProductCountResponse.of(productService.getProductCount(email)));
+    }
+
+    @Operation(summary = "비디오 스크랩 개수 조회", description = "비디오 스크랩 개수 정보를 조회할 수 있습니다.")
+    @GetMapping("/v1/scraps/videos/count")
+    public ApiResponse<GetVideoCountResponse> getVideoCount(Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.success(GetVideoCountResponse.of(videoService.getVideoCount(email)));
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetArticleCountResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetArticleCountResponse.java
@@ -1,0 +1,12 @@
+package com.forever.dadamda.dto.scrap;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class GetArticleCountResponse {
+
+    private Long count;
+
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetOtherCountResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetOtherCountResponse.java
@@ -1,0 +1,11 @@
+package com.forever.dadamda.dto.scrap;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class GetOtherCountResponse {
+
+    private Long count;
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetProductCountResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetProductCountResponse.java
@@ -1,0 +1,11 @@
+package com.forever.dadamda.dto.scrap;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class GetProductCountResponse {
+
+    private Long count;
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetScrapCountResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetScrapCountResponse.java
@@ -1,0 +1,11 @@
+package com.forever.dadamda.dto.scrap;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class GetScrapCountResponse {
+
+    private Long count;
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/GetVideoCountResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/GetVideoCountResponse.java
@@ -1,0 +1,11 @@
+package com.forever.dadamda.dto.scrap;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class GetVideoCountResponse {
+
+    private Long count;
+}

--- a/src/main/java/com/forever/dadamda/repository/ArticleRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/ArticleRepository.java
@@ -13,4 +13,5 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     Optional<Article> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 
+    Long countByUserAndDeletedDateIsNull(User user);
 }

--- a/src/main/java/com/forever/dadamda/repository/OtherRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/OtherRepository.java
@@ -13,4 +13,5 @@ public interface OtherRepository extends JpaRepository<Other, Long> {
 
     Optional<Other> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 
+    Long countByUserAndDeletedDateIsNull(User user);
 }

--- a/src/main/java/com/forever/dadamda/repository/ProductRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/ProductRepository.java
@@ -12,4 +12,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Slice<Product>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
 
     Optional<Product> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
+
+    Long countByUserAndDeletedDateIsNull(User user);
 }

--- a/src/main/java/com/forever/dadamda/repository/ScrapRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/ScrapRepository.java
@@ -9,7 +9,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+
     Optional<Scrap> findByPageUrlAndUserAndDeletedDateIsNull(String pageUrl, User user);
+
     Optional<Scrap> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
+
     Optional<Slice<Scrap>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
+
+    Long countByUserAndDeletedDateIsNull(User user);
 }

--- a/src/main/java/com/forever/dadamda/repository/VideoRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/VideoRepository.java
@@ -13,4 +13,5 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
 
     Optional<Video> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 
+    Long countByUserAndDeletedDateIsNull(User user);
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
@@ -6,6 +6,7 @@ import com.forever.dadamda.entity.scrap.Article;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.ArticleRepository;
+import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONObject;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final UserService userService;
 
     @Transactional
     public Article saveArticle(JSONObject crawlingResponse, User user, String pageUrl) {
@@ -51,5 +53,11 @@ public class ArticleService {
                 updateScrapRequest.getBlogName());
 
         return article;
+    }
+
+    @Transactional
+    public Long getArticleCount(String email) {
+        User user = userService.validateUser(email);
+        return articleRepository.countByUserAndDeletedDateIsNull(user);
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
@@ -6,6 +6,7 @@ import com.forever.dadamda.entity.scrap.Other;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.OtherRepository;
+import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONObject;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OtherService {
 
     private final OtherRepository otherRepository;
+    private final UserService userService;
 
     @Transactional
     public Other saveOther(JSONObject crawlingResponse, User user, String pageUrl) {
@@ -35,5 +37,11 @@ public class OtherService {
         other.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
                 updateScrapRequest.getSiteName());
         return other;
+    }
+
+    @Transactional
+    public Long getOtherCount(String email) {
+        User user = userService.validateUser(email);
+        return otherRepository.countByUserAndDeletedDateIsNull(user);
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
@@ -6,6 +6,7 @@ import com.forever.dadamda.entity.scrap.Product;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.ProductRepository;
+import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.JSONObject;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final UserService userService;
 
     @Transactional
     public Product saveProduct(JSONObject crawlingResponse, User user, String pageUrl) {
@@ -37,5 +39,11 @@ public class ProductService {
                 updateScrapRequest.getSiteName());
         product.updateProduct(updateScrapRequest.getPrice());
         return product;
+    }
+
+    @Transactional
+    public Long getProductCount(String email) {
+        User user = userService.validateUser(email);
+        return productRepository.countByUserAndDeletedDateIsNull(user);
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
@@ -2,25 +2,13 @@ package com.forever.dadamda.service.scrap;
 
 import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.scrap.CreateScrapResponse;
-import com.forever.dadamda.dto.scrap.GetArticleResponse;
-import com.forever.dadamda.dto.scrap.GetOtherResponse;
-import com.forever.dadamda.dto.scrap.GetProductResponse;
 import com.forever.dadamda.dto.scrap.GetScrapResponse;
-import com.forever.dadamda.dto.scrap.GetVideoResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
-import com.forever.dadamda.entity.scrap.Article;
-import com.forever.dadamda.entity.scrap.Other;
-import com.forever.dadamda.entity.scrap.Product;
 import com.forever.dadamda.entity.scrap.Scrap;
-import com.forever.dadamda.entity.scrap.Video;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.InvalidException;
 import com.forever.dadamda.exception.NotFoundException;
-import com.forever.dadamda.repository.ArticleRepository;
-import com.forever.dadamda.repository.OtherRepository;
-import com.forever.dadamda.repository.ProductRepository;
 import com.forever.dadamda.repository.ScrapRepository;
-import com.forever.dadamda.repository.VideoRepository;
 import com.forever.dadamda.service.WebClientService;
 import com.forever.dadamda.service.user.UserService;
 import org.springframework.data.domain.PageRequest;
@@ -39,10 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ScrapService {
 
     private final ScrapRepository scrapRepository;
-    private final ProductRepository productRepository;
-    private final VideoRepository videoRepository;
-    private final ArticleRepository articleRepository;
-    private final OtherRepository otherRepository;
     private final VideoService videoService;
     private final ArticleService articleService;
     private final ProductService productService;
@@ -109,69 +93,7 @@ public class ScrapService {
         Slice<Scrap> scrapSlice = scrapRepository.findAllByUserAndDeletedDateIsNull(user,
                 pageRequest).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
 
-        Slice<GetScrapResponse> getScrapResponseSlice = scrapSlice.map(GetScrapResponse::of);
-        return getScrapResponseSlice;
-    }
-
-    @Transactional
-    public Slice<GetProductResponse> getProducts(String email, Pageable pageable) {
-        User user = userService.validateUser(email);
-
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Product> scrapSlice = productRepository.findAllByUserAndDeletedDateIsNull(user,
-                pageRequest).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
-
-        Slice<GetProductResponse> getProductsResponseSlice = scrapSlice.map(GetProductResponse::of);
-        return getProductsResponseSlice;
-    }
-
-    @Transactional
-    public Slice<GetVideoResponse> getVideos(String email, Pageable pageable) {
-        User user = userService.validateUser(email);
-
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Video> videoSlice = videoRepository.findAllByUserAndDeletedDateIsNull(user,
-                pageRequest).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
-
-        Slice<GetVideoResponse> getVideosResponseSlice = videoSlice.map(GetVideoResponse::of);
-        return getVideosResponseSlice;
-    }
-
-    @Transactional
-    public Slice<GetArticleResponse> getArticles(String email, Pageable pageable) {
-        User user = userService.validateUser(email);
-
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Article> articleSlice = articleRepository.findAllByUserAndDeletedDateIsNull(user,
-                pageRequest).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
-
-        Slice<GetArticleResponse> getArticlesResponseSlice = articleSlice.map(
-                GetArticleResponse::of);
-        return getArticlesResponseSlice;
-    }
-
-    @Transactional
-    public Slice<GetOtherResponse> getOthers(String email, Pageable pageable) {
-        User user = userService.validateUser(email);
-
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Other> otherSlice = otherRepository.findAllByUserAndDeletedDateIsNull(user,
-                pageRequest).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
-
-        Slice<GetOtherResponse> getOthersResponseSlice = otherSlice.map(GetOtherResponse::of);
-        return getOthersResponseSlice;
+        return scrapSlice.map(GetScrapResponse::of);
     }
 
     @Transactional

--- a/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
@@ -49,7 +49,6 @@ public class ScrapService {
     private final OtherService otherService;
     private final WebClientService webClientService;
     private final UserService userService;
-    //private final MemoService memoService;
 
     @Transactional
     public CreateScrapResponse createScraps(String email, String pageUrl) throws ParseException {
@@ -189,5 +188,11 @@ public class ScrapService {
             default:
                 return otherService.updateOther(user, updateScrapRequest);
         }
+    }
+
+    @Transactional
+    public Long getScrapCount(String email) {
+        User user = userService.validateUser(email);
+        return scrapRepository.countByUserAndDeletedDateIsNull(user);
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
@@ -4,6 +4,7 @@ import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Video;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.service.user.UserService;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.VideoRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class VideoService {
 
     private final VideoRepository videoRepository;
+    private final UserService userService;
 
     @Transactional
     public Video saveVideo(JSONObject crawlingResponse, User user, String pageUrl) {
@@ -94,5 +96,11 @@ public class VideoService {
                 updateScrapRequest.getPlayTime(), updateScrapRequest.getPublishedDate(),
                 updateScrapRequest.getGenre());
         return video;
+    }
+
+    @Transactional
+    public Long getVideoCount(String email) {
+        User user = userService.validateUser(email);
+        return videoRepository.countByUserAndDeletedDateIsNull(user);
     }
 }


### PR DESCRIPTION
## 개요
- DAD-550

## 작업사항
- 스크랩 개수 조회 API 구현
- scrapService에서 각각의 서비스에 해당하는 부분을 해당 서비스로 이동
- 스웨거에 운영 서버 url 추가