### PR TITLE
[DAD-814] feat: elasticCache redis 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,6 @@ dependencies {
     implementation 'io.sentry:sentry-spring-boot-starter:6.28.0'
 
     // redis
-//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-//    implementation 'org.springframework.session:spring-session-data-redis:2.6.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis:2.6.1'
 }

--- a/src/main/java/com/forever/dadamda/config/RedisConfig.java
+++ b/src/main/java/com/forever/dadamda/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.forever.dadamda.config;
+
+import org.springframework.beans.factory.annotation.Value;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@ConditionalOnProperty(value = "spring.session.store-type", matchIfMissing = true, havingValue = "redis")
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 10)
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    ConfigureRedisAction configureRedisAction() {
+        return ConfigureRedisAction.NO_OP;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,6 +20,9 @@ spring:
             redirect-uri : test
             scope: test
 
+  session:
+    store-type: none
+
 security :
   jwt :
     token:


### PR DESCRIPTION
## 개요
- DAD-814

## 작업사항
- elasticCache redis 설정 추가
- 테스트 코드에서는 redis 의존성 제거

## 참고 자료
- https://velog.io/@dasd412/JUnit-테스트에서-카프카-의존성-제외하기
- https://loosie.tistory.com/814
- https://velog.io/@daoh98/AWS-ElastiCache-와-Redis-적용
- https://github.com/SWM-team-forever/dadamda-backend/pulls?q=redis