### PR TITLE
[DAD-812] fix: 스크랩 검색시, 오래된 순에서 최신 순서대로 정렬 기준 변경

### DIFF
--- a/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
@@ -90,9 +90,13 @@ public class ArticleService {
     public Slice<GetArticleResponse> searchArticles(String email, String keyword, Pageable pageable) {
         User user = userService.validateUser(email);
 
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
+
         Slice<Article> scrapSlice = articleRepository
                 .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageable)
+                        user, keyword, keyword, pageRequest)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
 
         return scrapSlice.map(GetArticleResponse::of);

--- a/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
@@ -75,9 +75,13 @@ public class OtherService {
     public Slice<GetOtherResponse> searchOthers(String email, String keyword, Pageable pageable) {
         User user = userService.validateUser(email);
 
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
+
         Slice<Other> otherSlice = otherRepository
                 .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageable)
+                        user, keyword, keyword, pageRequest)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
 
         return otherSlice.map(GetOtherResponse::of);

--- a/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
@@ -77,9 +77,13 @@ public class ProductService {
     public Slice<GetProductResponse> searchProducts(String email, String keyword, Pageable pageable) {
         User user = userService.validateUser(email);
 
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
+
         Slice<Product> scrapSlice = productRepository
                 .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageable)
+                        user, keyword, keyword, pageRequest)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
 
         return scrapSlice.map(GetProductResponse::of);

--- a/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
@@ -124,9 +124,13 @@ public class ScrapService {
     public Slice<GetScrapResponse> searchScraps(String email, String keyword, Pageable pageable) {
         User user = userService.validateUser(email);
 
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
+
         Slice<Scrap> scrapSlice = scrapRepository
                 .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageable)
+                        user, keyword, keyword, pageRequest)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
 
         return scrapSlice.map(GetScrapResponse::of);

--- a/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
@@ -142,9 +142,13 @@ public class VideoService {
     public Slice<GetVideoResponse> searchVideos(String email, String keyword, Pageable pageable) {
         User user = userService.validateUser(email);
 
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
+        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                sort);
+
         Slice<Video> scrapSlice = videoRepository
                 .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageable)
+                        user, keyword, keyword, pageRequest)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
 
         return scrapSlice.map(GetVideoResponse::of);

--- a/src/test/java/com/forever/dadamda/controller/scrap/OtherControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/scrap/OtherControllerTest.java
@@ -27,14 +27,14 @@ public class OtherControllerTest {
 
     @Test
     @WithCustomMockUser
-    public void should_the_3rd_scrap_is_the_first_one_When_page_is_1_size_is_2_and_there_are_4_scraps() throws Exception {
-        //page 1, size 2이고 검색된 기타 스크랩이 3개일 때, 3번째 스크랩이 첫 번째로 나오는지 확인
+    public void should_the_2rd_scrap_is_the_first_one_When_page_is_1_size_is_2_and_there_are_4_scraps() throws Exception {
+        //page 1, size 2이고 검색된 기타 스크랩이 4개일 때, 2번째 스크랩이 첫 번째로 나오는지 확인
         mockMvc.perform(get("/v1/scraps/others/search")
                         .param("keyword", "google")
                         .param("page", "1")
                         .param("size", "2")
                         .header("X-AUTH-TOKEN", "aaaaaaa"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("Google Main Page 3"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("Google Main Page 2"));
     }
 }

--- a/src/test/java/com/forever/dadamda/controller/scrap/VideoControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/scrap/VideoControllerTest.java
@@ -28,14 +28,14 @@ public class VideoControllerTest {
     @Test
     @WithCustomMockUser
     public void should_videos_are_sorted_in_created_date_When_searching_for_multiple_scraps() throws Exception {
-        //여러 개의 스크랩 검색시, 생성 날짜 순서 대로 정렬 되었는 지 확인
+        //여러 개의 스크랩 검색시, 최신 순서 대로 정렬 되었는 지 확인
         mockMvc.perform(get("/v1/scraps/videos/search")
                         .param("keyword", "오늘")
                         .param("page", "0")
                         .param("size", "10")
                         .header("X-AUTH-TOKEN", "aaaaaaa"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("오늘의 일기 1"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].title").value("오늘의 일기 2"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("오늘의 일기 2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].title").value("오늘의 일기 1"));
     }
 }

--- a/src/test/resources/othersetup.sql
+++ b/src/test/resources/othersetup.sql
@@ -3,14 +3,14 @@ INSERT INTO users (user_id, name, provider, role, email, profile_url)
 VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
 
 -- Other 데이터 삽입
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type)
-VALUES (1, 1, 'https://www.google.com/1', 'Google Main Page 1', '구글 메인 페이지 1 입니다.', 'Other');
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type, created_date)
+VALUES (1, 1, 'https://www.google.com/1', 'Google Main Page 1', '구글 메인 페이지 1 입니다.', 'Other', '2023-01-01 11:11:01');
 
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type)
-VALUES (1, 2, 'https://www.google.com/2', 'Google Main Page 2', '구글 메인 페이지 2 입니다.', 'Other');
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type, created_date)
+VALUES (1, 2, 'https://www.google.com/2', 'Google Main Page 2', '구글 메인 페이지 2 입니다.', 'Other', '2023-01-02 11:11:01');
 
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type)
-VALUES (1, 3, 'https://www.google.com/3', 'Google Main Page 3', '구글 메인 페이지 3 입니다.', 'Other');
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type, created_date)
+VALUES (1, 3, 'https://www.google.com/3', 'Google Main Page 3', '구글 메인 페이지 3 입니다.', 'Other', '2023-01-03 11:11:01');
 
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type)
-VALUES (1, 4, 'https://www.google.com/4', 'Google Main Page 4', '구글 메인 페이지 4 입니다.', 'Other');
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type, created_date)
+VALUES (1, 4, 'https://www.google.com/4', 'Google Main Page 4', '구글 메인 페이지 4 입니다.', 'Other', '2023-01-04 11:11:01');

--- a/src/test/resources/setup.sql
+++ b/src/test/resources/setup.sql
@@ -3,17 +3,19 @@ INSERT INTO users (user_id, name, provider, role, email, profile_url)
 VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
 
 -- Product 데이터 삽입
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type)
-VALUES (1, 1, 'https://www.coupang.com', 'Coupang의 맥북 상품', 'MacBook Pro 16인치 2019년형', 'Coupang', 'Product');
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, created_date)
+VALUES (1, 1, 'https://www.coupang.com', 'Coupang의 맥북 상품', 'MacBook Pro 16인치 2019년형', 'Coupang', 'Product', '2023-01-10 09:11:01');
 
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, watched_cnt, play_time, published_date)
-VALUES (1, 2, 'https://www.youtube.com/123', '오늘의 일기 1', 'Today is sunny', 'Youtube', 'Video', 10, 100, '2020-01-01');
+-- Video 데이터 삽입
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, watched_cnt, play_time, published_date, created_date)
+VALUES (1, 2, 'https://www.youtube.com/123', '오늘의 일기 1', 'Today is sunny', 'Youtube', 'Video', 10, 100, '2020-01-01', '2023-01-01 11:11:01');
 
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, watched_cnt, play_time, published_date)
-VALUES (1, 3, 'https://www.youtube.com/1234', '오늘의 일기 2', 'Today is rainy', 'Youtube', 'Video', 100, 1000, '2020-01-01');
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, watched_cnt, play_time, published_date, created_date)
+VALUES (1, 3, 'https://www.youtube.com/1234', '오늘의 일기 2', 'Today is rainy', 'Youtube', 'Video', 100, 1000, '2020-01-01', '2023-01-02 11:11:01');
 
-INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, published_date)
-VALUES (1, 4, 'https://www.velog.com/1234', '오늘의 일기 3', 'Today is rainy', 'Velog', 'Article', '2020-01-01');
+-- Article 데이터 삽입
+INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, published_date, created_date)
+VALUES (1, 4, 'https://www.velog.com/1234', '오늘의 일기 3', 'Today is rainy', 'Velog', 'Article', '2020-01-01', '2023-01-03 11:11:01');
 
 -- 메모 데이터 삽입
 INSERT INTO memo (scrap_id, memo_id, memo_text, created_date)


### PR DESCRIPTION
## 개요
- DAD-812

## 작업사항
- 스크랩 검색시, 오래된 순에서 최신 순서대로 정렬 기준 변경
- 기존 스크랩 검색 테스트 코드 수정

## 추후 변경할 요소
- 현재 스크랩(영상, 아티클, 기타, 상품)이 동일한 구조의 서비스를 가지고 있어서 디자인 패턴 적용하여 수정에 용이한 구조로 변경할 예정