### PR TITLE
[DAD-763] feat: 장소 스크랩 저장 기능 구현 및 webClientService 로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
     testRuntimeOnly 'com.h2database:h2'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import java.math.BigDecimal;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -52,4 +53,14 @@ public class WebClientBodyResponse {
     @JsonProperty("homepage")
     private String homepageUrl;
     private String category;
+
+    @Builder
+    public WebClientBodyResponse(String title, String address, BigDecimal latitude,
+            BigDecimal longitude, String phoneNumber) {
+        this.address = address;
+        this.title = title;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
@@ -55,8 +55,9 @@ public class WebClientBodyResponse {
     private String category;
 
     @Builder
-    public WebClientBodyResponse(String title, String address, BigDecimal latitude,
+    public WebClientBodyResponse(String pageUrl, String title, String address, BigDecimal latitude,
             BigDecimal longitude, String phoneNumber) {
+        this.pageUrl = pageUrl;
         this.address = address;
         this.title = title;
         this.latitude = latitude;

--- a/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
@@ -1,0 +1,55 @@
+package com.forever.dadamda.dto.webClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor
+public class WebClientBodyResponse {
+
+    // 공통 부분
+    private String type;
+    private String description;
+    private String pageUrl;
+    private String siteName;
+    private String thumbnailUrl;
+    private String title;
+
+    // Video 부분
+    private String channelImageUrl;
+    private String channelName;
+    private String embedUrl;
+    private Long playTime;
+    private Long watchedCnt;
+    private Long publishedDate; // Video, Article 공통 부분
+
+    // Article 부분
+    private String author;
+    private String authorImageUrl;
+    private String blogName;
+
+    // Product 부분
+    private String price;
+
+    // Place 부분
+    private String address;
+
+    @JsonProperty("lat")
+    private BigDecimal latitude;
+
+    @JsonProperty("lng")
+    private BigDecimal longitude;
+
+    @JsonProperty("phonenum")
+    private String phoneNumber;
+    private String zipCode;
+
+    @JsonProperty("homepage")
+    private String homepageUrl;
+    private String category;
+}

--- a/src/main/java/com/forever/dadamda/dto/webClient/WebClientHeaderResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/webClient/WebClientHeaderResponse.java
@@ -1,0 +1,10 @@
+package com.forever.dadamda.dto.webClient;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WebClientHeaderResponse {
+    private String Content;
+}

--- a/src/main/java/com/forever/dadamda/dto/webClient/WebClientResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/webClient/WebClientResponse.java
@@ -1,0 +1,14 @@
+package com.forever.dadamda.dto.webClient;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WebClientResponse {
+
+    private String statusCode;
+    private WebClientHeaderResponse header;
+    private String body;
+}
+

--- a/src/main/java/com/forever/dadamda/service/WebClientService.java
+++ b/src/main/java/com/forever/dadamda/service/WebClientService.java
@@ -26,11 +26,9 @@ public class WebClientService {
                     .bodyValue(bodyMap)
                     .retrieve()
                     .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
-                        System.out.println("Response status code: " + clientResponse.statusCode());
                         throw new RuntimeException("4xx");
                     })
                     .onStatus(HttpStatus::is4xxClientError, clientResponse -> {
-                        System.out.println("Response status code: " + clientResponse.statusCode());
                         throw new RuntimeException("5xx");
                     })
                     .bodyToMono(WebClientResponse.class)

--- a/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
@@ -1,6 +1,7 @@
 package com.forever.dadamda.service.scrap;
 
 import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
 import com.forever.dadamda.dto.scrap.article.GetArticleResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Article;
@@ -9,9 +10,7 @@ import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.scrap.ArticleRepository;
 import com.forever.dadamda.service.TimeService;
 import com.forever.dadamda.service.user.UserService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import net.minidev.json.JSONObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -27,28 +26,17 @@ public class ArticleService {
     private final UserService userService;
 
     @Transactional
-    public Article saveArticle(JSONObject crawlingResponse, User user, String pageUrl) {
+    public Article saveArticle(WebClientBodyResponse crawlingResponse, User user, String pageUrl) {
 
         Article article = Article.builder().user(user).pageUrl(pageUrl)
-                .title(Optional.ofNullable(crawlingResponse.get("title")).map(Object::toString)
-                        .orElse(null))
-                .thumbnailUrl(Optional.ofNullable(crawlingResponse.get("thumbnail_url"))
-                        .map(Object::toString).orElse(null))
-                .description(Optional.ofNullable(crawlingResponse.get("description"))
-                        .map(Object::toString).orElse(null))
-                .author(Optional.ofNullable(crawlingResponse.get("author")).map(Object::toString)
-                        .orElse(null))
-                .authorImageUrl(Optional.ofNullable(crawlingResponse.get("author_image_url"))
-                        .map(Object::toString).orElse(null))
-                .blogName(
-                        Optional.ofNullable(crawlingResponse.get("blog_name")).map(Object::toString)
-                                .orElse(null))
-                .publishedDate(Optional.ofNullable(crawlingResponse.get("published_date"))
-                        .map(Object::toString).map(Long::parseLong).map(
-                                TimeService::fromUnixTime).orElse(null))
-                .siteName(
-                        Optional.ofNullable(crawlingResponse.get("site_name")).map(Object::toString)
-                                .orElse(null)).build();
+                .title(crawlingResponse.getTitle())
+                .thumbnailUrl(crawlingResponse.getThumbnailUrl())
+                .description(crawlingResponse.getDescription())
+                .author(crawlingResponse.getAuthor())
+                .authorImageUrl(crawlingResponse.getAuthorImageUrl())
+                .blogName(crawlingResponse.getBlogName())
+                .publishedDate(TimeService.fromUnixTime(crawlingResponse.getPublishedDate()))
+                .siteName(crawlingResponse.getSiteName()).build();
 
         return articleRepository.save(article);
     }
@@ -87,7 +75,8 @@ public class ArticleService {
     }
 
     @Transactional
-    public Slice<GetArticleResponse> searchArticles(String email, String keyword, Pageable pageable) {
+    public Slice<GetArticleResponse> searchArticles(String email, String keyword,
+            Pageable pageable) {
         User user = userService.validateUser(email);
 
         Slice<Article> scrapSlice = articleRepository

--- a/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
@@ -1,16 +1,15 @@
 package com.forever.dadamda.service.scrap;
 
 import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
 import com.forever.dadamda.dto.scrap.other.GetOtherResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Other;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.scrap.OtherRepository;
-import java.util.Optional;
 import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
-import net.minidev.json.JSONObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -26,16 +25,12 @@ public class OtherService {
     private final UserService userService;
 
     @Transactional
-    public Other saveOther(JSONObject crawlingResponse, User user, String pageUrl) {
+    public Other saveOther(WebClientBodyResponse crawlingResponse, User user, String pageUrl) {
 
         Other other = Other.builder().user(user).pageUrl(pageUrl)
-                .title(Optional.ofNullable(crawlingResponse.get("title")).map(Object::toString)
-                        .orElse(null))
-                .thumbnailUrl(Optional.ofNullable(crawlingResponse.get("thumbnail_url"))
-                        .map(Object::toString).orElse(null))
-                .description(Optional.ofNullable(crawlingResponse.get("description"))
-                        .map(Object::toString)
-                        .orElse(null))
+                .title(crawlingResponse.getTitle())
+                .thumbnailUrl(crawlingResponse.getThumbnailUrl())
+                .description(crawlingResponse.getDescription())
                 .build();
 
         return otherRepository.save(other);

--- a/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
@@ -40,7 +40,7 @@ public class PlaceService {
     public Place savePlace(WebClientBodyResponse crawlingResponse, User user, String pageUrl) {
 
         Place place = Place.builder()
-                .user(user).pageUrl(pageUrl)
+                .user(user).pageUrl(crawlingResponse.getPageUrl())
                 .title(crawlingResponse.getTitle())
                 .thumbnailUrl(crawlingResponse.getThumbnailUrl())
                 .description(crawlingResponse.getDescription())

--- a/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
@@ -1,16 +1,14 @@
 package com.forever.dadamda.service.scrap;
 
 import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
 import com.forever.dadamda.dto.scrap.place.GetPlaceResponse;
 import com.forever.dadamda.entity.scrap.Place;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.scrap.PlaceRepository;
 import com.forever.dadamda.service.user.UserService;
-import java.math.BigDecimal;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import net.minidev.json.JSONObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -39,39 +37,21 @@ public class PlaceService {
     }
 
     @Transactional
-    public Place savePlace(JSONObject crawlingResponse, User user, String pageUrl) {
+    public Place savePlace(WebClientBodyResponse crawlingResponse, User user, String pageUrl) {
 
         Place place = Place.builder()
                 .user(user).pageUrl(pageUrl)
-                .title(Optional.ofNullable(crawlingResponse.get("title")).map(Object::toString)
-                        .orElse(null))
-                .thumbnailUrl(Optional.ofNullable(crawlingResponse.get("thumbnail_url"))
-                        .map(Object::toString).orElse(null))
-                .description(Optional.ofNullable(crawlingResponse.get("description"))
-                        .map(Object::toString)
-                        .orElse(null))
-                .address(Optional.ofNullable(crawlingResponse.get("address")).map(Object::toString)
-                        .orElse(null))
-                .latitude(Optional.ofNullable(crawlingResponse.get("lat")).map(
-                                lat -> new BigDecimal(lat.toString()))
-                        .orElse(null))
-                .longitude(Optional.ofNullable(crawlingResponse.get("lng"))
-                        .map(lng -> new BigDecimal(lng.toString()))
-                        .orElse(null))
-                .phoneNumber(Optional.ofNullable(crawlingResponse.get("phonenum"))
-                        .map(Object::toString)
-                        .orElse(null))
-                .zipCode(Optional.ofNullable(crawlingResponse.get("zipcode")).map(Object::toString)
-                        .orElse(null))
-                .homepageUrl(Optional.ofNullable(crawlingResponse.get("homepage"))
-                        .map(Object::toString)
-                        .orElse(null))
-                .category(
-                        Optional.ofNullable(crawlingResponse.get("category")).map(Object::toString)
-                                .orElse(null))
-                .siteName(
-                        Optional.ofNullable(crawlingResponse.get("site_name")).map(Object::toString)
-                                .orElse(null))
+                .title(crawlingResponse.getTitle())
+                .thumbnailUrl(crawlingResponse.getThumbnailUrl())
+                .description(crawlingResponse.getDescription())
+                .address(crawlingResponse.getAddress())
+                .latitude(crawlingResponse.getLatitude())
+                .longitude(crawlingResponse.getLongitude())
+                .phoneNumber(crawlingResponse.getPhoneNumber())
+                .zipCode(crawlingResponse.getZipCode())
+                .homepageUrl(crawlingResponse.getHomepageUrl())
+                .category(crawlingResponse.getCategory())
+                .siteName(crawlingResponse.getSiteName())
                 .build();
 
         return placeRepository.save(place);

--- a/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
@@ -2,11 +2,15 @@ package com.forever.dadamda.service.scrap;
 
 import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.scrap.place.GetPlaceResponse;
+import com.forever.dadamda.entity.scrap.Place;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.scrap.PlaceRepository;
 import com.forever.dadamda.service.user.UserService;
+import java.math.BigDecimal;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import net.minidev.json.JSONObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -32,5 +36,44 @@ public class PlaceService {
         return placeRepository.findAllByUserAndDeletedDateIsNull(user, pageRequest)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP))
                 .map(GetPlaceResponse::of);
+    }
+
+    @Transactional
+    public Place savePlace(JSONObject crawlingResponse, User user, String pageUrl) {
+
+        Place place = Place.builder()
+                .user(user).pageUrl(pageUrl)
+                .title(Optional.ofNullable(crawlingResponse.get("title")).map(Object::toString)
+                        .orElse(null))
+                .thumbnailUrl(Optional.ofNullable(crawlingResponse.get("thumbnail_url"))
+                        .map(Object::toString).orElse(null))
+                .description(Optional.ofNullable(crawlingResponse.get("description"))
+                        .map(Object::toString)
+                        .orElse(null))
+                .address(Optional.ofNullable(crawlingResponse.get("address")).map(Object::toString)
+                        .orElse(null))
+                .latitude(Optional.ofNullable(crawlingResponse.get("lat")).map(
+                                lat -> new BigDecimal(lat.toString()))
+                        .orElse(null))
+                .longitude(Optional.ofNullable(crawlingResponse.get("lng"))
+                        .map(lng -> new BigDecimal(lng.toString()))
+                        .orElse(null))
+                .phoneNumber(Optional.ofNullable(crawlingResponse.get("phonenum"))
+                        .map(Object::toString)
+                        .orElse(null))
+                .zipCode(Optional.ofNullable(crawlingResponse.get("zipcode")).map(Object::toString)
+                        .orElse(null))
+                .homepageUrl(Optional.ofNullable(crawlingResponse.get("homepage"))
+                        .map(Object::toString)
+                        .orElse(null))
+                .category(
+                        Optional.ofNullable(crawlingResponse.get("category")).map(Object::toString)
+                                .orElse(null))
+                .siteName(
+                        Optional.ofNullable(crawlingResponse.get("site_name")).map(Object::toString)
+                                .orElse(null))
+                .build();
+
+        return placeRepository.save(place);
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
@@ -1,16 +1,15 @@
 package com.forever.dadamda.service.scrap;
 
 import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
 import com.forever.dadamda.dto.scrap.product.GetProductResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Product;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.scrap.ProductRepository;
-import java.util.Optional;
 import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
-import net.minidev.json.JSONObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -26,18 +25,13 @@ public class ProductService {
     private final UserService userService;
 
     @Transactional
-    public Product saveProduct(JSONObject crawlingResponse, User user, String pageUrl) {
+    public Product saveProduct(WebClientBodyResponse crawlingResponse, User user, String pageUrl) {
 
         Product product = Product.builder().user(user).pageUrl(pageUrl)
-                .title(Optional.ofNullable(crawlingResponse.get("title")).map(Object::toString)
-                        .orElse(null))
-                .thumbnailUrl(Optional.ofNullable(crawlingResponse.get("thumbnail_url"))
-                        .map(Object::toString).orElse(null))
-                .price(Optional.ofNullable(crawlingResponse.get("price")).map(Object::toString)
-                        .orElse(null))
-                .siteName(
-                        Optional.ofNullable(crawlingResponse.get("site_name")).map(Object::toString)
-                                .orElse(null)).build();
+                .title(crawlingResponse.getTitle())
+                .thumbnailUrl(crawlingResponse.getThumbnailUrl())
+                .price(crawlingResponse.getPrice())
+                .siteName(crawlingResponse.getSiteName()).build();
 
         return productRepository.save(product);
     }

--- a/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
@@ -33,6 +33,7 @@ public class ScrapService {
     private final OtherService otherService;
     private final WebClientService webClientService;
     private final UserService userService;
+    private final PlaceService placeService;
 
     @Transactional
     public CreateScrapResponse createScraps(String email, String pageUrl) throws ParseException {
@@ -70,6 +71,8 @@ public class ScrapService {
                 return articleService.saveArticle(crawlingResponse, user, pageUrl);
             case "product":
                 return productService.saveProduct(crawlingResponse, user, pageUrl);
+            case "place" :
+                return placeService.savePlace(crawlingResponse, user, pageUrl);
         }
         return otherService.saveOther(crawlingResponse, user, pageUrl);
     }

--- a/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
@@ -1,6 +1,7 @@
 package com.forever.dadamda.service.scrap;
 
 import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
 import com.forever.dadamda.dto.scrap.video.GetVideoResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Video;
@@ -9,9 +10,7 @@ import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.scrap.VideoRepository;
 import com.forever.dadamda.service.TimeService;
 import com.forever.dadamda.service.user.UserService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import net.minidev.json.JSONObject;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -73,35 +72,19 @@ public class VideoService {
 
 
     @Transactional
-    public Video saveVideo(JSONObject crawlingResponse, User user, String pageUrl) {
+    public Video saveVideo(WebClientBodyResponse crawlingResponse, User user, String pageUrl) {
 
         Video video = Video.builder().user(user).pageUrl(pageUrl)
-                .title(Optional.ofNullable(crawlingResponse.get("title")).map(Object::toString)
-                        .orElse(null))
-                .thumbnailUrl(Optional.ofNullable(crawlingResponse.get("thumbnail_url"))
-                        .map(Object::toString).orElse(null))
-                .description(Optional.ofNullable(crawlingResponse.get("description"))
-                        .map(Object::toString).orElse(null))
-                .embedUrl(
-                        Optional.ofNullable(crawlingResponse.get("embed_url")).map(Object::toString)
-                                .orElse(null))
-                .channelName(Optional.ofNullable(crawlingResponse.get("channel_name"))
-                        .map(Object::toString)
-                        .orElse(null))
-                .channelImageUrl(Optional.ofNullable(crawlingResponse.get("channel_image_url"))
-                        .map(Object::toString).orElse(null))
-                .watchedCnt(Optional.ofNullable(crawlingResponse.get("watched_cnt"))
-                        .map(Object::toString)
-                        .map(Long::parseLong).orElse(null))
-                .playTime(
-                        Optional.ofNullable(crawlingResponse.get("play_time")).map(Object::toString)
-                                .map(Long::parseLong).orElse(null))
-                .publishedDate(Optional.ofNullable(crawlingResponse.get("published_date"))
-                        .map(Object::toString).map(Long::parseLong)
-                        .map(TimeService::fromUnixTime).orElse(null))
-                .siteName(
-                        Optional.ofNullable(crawlingResponse.get("site_name")).map(Object::toString)
-                                .orElse(null))
+                .title(crawlingResponse.getTitle())
+                .thumbnailUrl(crawlingResponse.getThumbnailUrl())
+                .description(crawlingResponse.getDescription())
+                .embedUrl(crawlingResponse.getEmbedUrl())
+                .channelName(crawlingResponse.getChannelName())
+                .channelImageUrl(crawlingResponse.getChannelImageUrl())
+                .watchedCnt(crawlingResponse.getWatchedCnt())
+                .playTime(crawlingResponse.getPlayTime())
+                .publishedDate(TimeService.fromUnixTime(crawlingResponse.getPublishedDate()))
+                .siteName(crawlingResponse.getSiteName())
                 .build();
 
         return videoRepository.save(video);

--- a/src/test/java/com/forever/dadamda/service/WebClientServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/WebClientServiceTest.java
@@ -1,0 +1,116 @@
+package com.forever.dadamda.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class WebClientServiceTest {
+
+    @Autowired
+    private WebClientService webClientService;
+
+    private MockWebServer mockWebServer;
+    private String mockWebServerUrl;
+
+    private final String mockScrap = "{\n"
+            + "  \"statusCode\": 200,\n"
+            + "  \"headers\": {\n"
+            + "    \"Content-Type\": \"application/json\"\n"
+            + "  },\n"
+            + "  \"body\": \"{\\\"type\\\": \\\"place\\\", \\\"page_url\\\": \\\"https://map.kakao.com/1234\\\", "
+            + "\\\"site_name\\\": \\\"KakaoMap\\\", \\\"lat\\\": 37.50359439708544, \\\"lng\\\": 127.04484896895218, "
+            + "\\\"title\\\": \\\"서울역\\\", \\\"address\\\": \\\"서울특별시 중구 소공동 세종대로18길 2\\\", "
+            + "\\\"phonenum\\\": \\\"1522-3232\\\", \\\"zipcode\\\": \\\"06151\\\", "
+            + "\\\"homepageUrl\\\": \\\"https://www.seoul.co.kr\\\", \\\"category\\\": \\\"지하철\\\"}\"\n"
+            + "}\n";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+        mockWebServerUrl = mockWebServer.url("/v1/crawling").toString();
+    }
+
+    @AfterEach
+    void terminate() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void should_title_is_returned_When_the_webClient_server_responds_successfully() {
+        // webClient 서버가 성공적으로 응답하는 경우, 정상적으로 title이 반환되는지 확인
+        //given
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(mockScrap)
+                .addHeader("Content-Type", "application/json"));
+
+        //when
+        WebClientBodyResponse webClientBodyResponse = webClientService.crawlingItem(
+                mockWebServerUrl, "https://www.naver.com");
+
+        //then
+        assertThat(webClientBodyResponse.getTitle()).isEqualTo("서울역");
+    }
+
+    @Test
+    void should_it_returns_null_When_property_is_not_in_the_response_body_value() {
+        // 응답 바디 값에 없는 author 속성의 경우, 해당 속성 값이 null로 반환되는지 확인
+        //given
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(mockScrap)
+                .addHeader("Content-Type", "application/json"));
+
+        //when
+        WebClientBodyResponse webClientBodyResponse = webClientService.crawlingItem(
+                mockWebServerUrl, "https://www.naver.com");
+
+        //then
+        assertThat(webClientBodyResponse.getAuthor()).isEqualTo(null);
+    }
+
+    @Test
+    void should_it_returns_null_When_property_value_of_the_response_body_is_different_from_the_webClientBodyResponse_property_value() {
+        // 응답 바디의 속성 값이 webClientBodyResponse 속성 값과 다른 경우, null로 반환되는지 확인
+        //given
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(mockScrap)
+                .addHeader("Content-Type", "application/json"));
+
+        //when
+        WebClientBodyResponse webClientBodyResponse = webClientService.crawlingItem(
+                mockWebServerUrl, "https://www.naver.com");
+
+        //then
+        assertThat(webClientBodyResponse.getHomepageUrl()).isEqualTo(null);
+    }
+
+    @Test
+    void should_it_returns_null_When_webClient_server_responds_unsuccessfully() {
+        // webClient 서버가 정상적으로 응답을 주지 않는 경우, null로 반환되는지 확인
+        //given
+        mockWebServer.enqueue(new MockResponse()
+                .setResponseCode(400)
+        );
+
+        //when
+        WebClientBodyResponse webClientBodyResponse = webClientService.crawlingItem(
+                mockWebServerUrl, "https://www.naver.com");
+
+        //then
+        assertThat(webClientBodyResponse).isEqualTo(null);
+    }
+}

--- a/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
@@ -34,7 +34,10 @@ public class PlaceServiceTest {
     @Autowired
     private PlaceRepository placeRepository;
 
-    String email = "1234@naver.com";
+    private final String email = "1234@naver.com";
+    private final String existingPageUrl = "https://www.kakao.map.com/maps/place/kakao";
+    private final String changedPageUrl = "https://www.kakao.map.com/maps/place/kakao2";
+
 
     @Test
     void should_the_precision_of_latitude_and_longitude_are_expressed_up_to_14_digits_When_getting_place_list() {
@@ -64,12 +67,9 @@ public class PlaceServiceTest {
         User user = userRepository.findById(1L).get();
 
         WebClientBodyResponse webClientBodyResponse = WebClientBodyResponse.builder()
-                .title("서울역 1호선")
-                .address("서울 용산구 한강대로 405 (우)04320")
-                .latitude(new BigDecimal("37.422"))
-                .longitude(new BigDecimal("-122.084"))
-                .phoneNumber("02-1544-7788")
-                .build();
+                .title("서울역 1호선").address("서울 용산구 한강대로 405 (우)04320")
+                .latitude(new BigDecimal("37.422")).longitude(new BigDecimal("-122.084"))
+                .phoneNumber("02-1544-7788").build();
 
         //when
         Place place = placeService.savePlace(webClientBodyResponse, user,
@@ -77,5 +77,26 @@ public class PlaceServiceTest {
 
         //then
         assertThat(place.getTitle()).isEqualTo(placeRepository.findById(1L).get().getTitle());
+    }
+
+    @Test
+    void should_it_is_saved_as_pageUrl_received_through_WebClientBodyResponse_When_saving_a_place() {
+        // WebClientBodyResponse를 통해 받은 pageUrl로 저장되는지 확인
+        //given
+        placeRepository.deleteAll();
+
+        User user = userRepository.findById(1L).get();
+
+        WebClientBodyResponse webClientBodyResponse = WebClientBodyResponse.builder()
+                .pageUrl(changedPageUrl).title("서울역 1호선").address("서울 용산구 한강대로 405 (우)04320")
+                .latitude(new BigDecimal("37.422")).longitude(new BigDecimal("-122.084"))
+                .phoneNumber("02-1544-7788").build();
+
+        //when
+        Place place = placeService.savePlace(webClientBodyResponse, user, existingPageUrl);
+
+        //then
+        assertThat(place.getPageUrl()).isEqualTo(changedPageUrl);
+        assertThat(placeRepository.findById(1L).get().getPageUrl()).isEqualTo(changedPageUrl);
     }
 }

--- a/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
@@ -4,12 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.forever.dadamda.dto.scrap.place.GetPlaceResponse;
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
 import com.forever.dadamda.entity.scrap.Place;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.repository.UserRepository;
 import com.forever.dadamda.repository.scrap.PlaceRepository;
 import java.math.BigDecimal;
-import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -63,16 +63,16 @@ public class PlaceServiceTest {
 
         User user = userRepository.findById(1L).get();
 
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("title", "서울역 1호선");
-        jsonObject.put("address", "서울 용산구 한강대로 405 (우)04320");
-        jsonObject.put("lat", 37.422);
-        jsonObject.put("lng", -122.084);
-        jsonObject.put("phonenum", "02-1544-7788");
-        jsonObject.put("zipcode", "123456");
+        WebClientBodyResponse webClientBodyResponse = WebClientBodyResponse.builder()
+                .title("서울역 1호선")
+                .address("서울 용산구 한강대로 405 (우)04320")
+                .latitude(new BigDecimal("37.422"))
+                .longitude(new BigDecimal("-122.084"))
+                .phoneNumber("02-1544-7788")
+                .build();
 
         //when
-        Place place = placeService.savePlace(jsonObject, user,
+        Place place = placeService.savePlace(webClientBodyResponse, user,
                 "https://www.kakao.map.com/maps/place/kakao");
 
         //then

--- a/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
@@ -1,9 +1,15 @@
 package com.forever.dadamda.service.scrap;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.forever.dadamda.dto.scrap.place.GetPlaceResponse;
+import com.forever.dadamda.entity.scrap.Place;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.repository.UserRepository;
+import com.forever.dadamda.repository.scrap.PlaceRepository;
 import java.math.BigDecimal;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,6 +27,12 @@ public class PlaceServiceTest {
 
     @Autowired
     private PlaceService placeService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
 
     String email = "1234@naver.com";
 
@@ -41,5 +53,29 @@ public class PlaceServiceTest {
 
         assertEquals(longitude.scale(), 14);
         assertEquals(longitude.precision(), 17);
+    }
+
+    @Test
+    void should_it_is_saved_as_the_first_scrap_When_storing_place_in_a_blank_scrap_db() {
+        // 아무 것도 없는 DB에 장소 스크랩 저장시, DB에 첫 번째 스크랩으로 저장되는지 확인
+        //given
+        placeRepository.deleteAll();
+
+        User user = userRepository.findById(1L).get();
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("title", "서울역 1호선");
+        jsonObject.put("address", "서울 용산구 한강대로 405 (우)04320");
+        jsonObject.put("lat", 37.422);
+        jsonObject.put("lng", -122.084);
+        jsonObject.put("phonenum", "02-1544-7788");
+        jsonObject.put("zipcode", "123456");
+
+        //when
+        Place place = placeService.savePlace(jsonObject, user,
+                "https://www.kakao.map.com/maps/place/kakao");
+
+        //then
+        assertThat(place.getTitle()).isEqualTo(placeRepository.findById(1L).get().getTitle());
     }
 }

--- a/src/test/java/com/forever/dadamda/service/scrap/ScrapServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/scrap/ScrapServiceTest.java
@@ -5,23 +5,29 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.forever.dadamda.dto.scrap.GetScrapResponse;
+import com.forever.dadamda.entity.scrap.Other;
+import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
+import com.forever.dadamda.repository.MemoRepository;
+import com.forever.dadamda.repository.UserRepository;
 import com.forever.dadamda.repository.scrap.ScrapRepository;
+import com.forever.dadamda.service.WebClientService;
+import net.minidev.json.parser.ParseException;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Sql(scripts = "classpath:truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
-@Sql(scripts = "classpath:setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@TestPropertySource(locations = "classpath:application-test.yml")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public class ScrapServiceTest {
 
     @Autowired
@@ -30,11 +36,22 @@ public class ScrapServiceTest {
     @Autowired
     private ScrapRepository scrapRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private WebClientService webClientService;
+
+    @Autowired
+    private MemoRepository memoRepository;
+
     String email = "1234@naver.com";
     Long existentScrapId = 1L;
     Long notExistentScrapId = 100L;
 
-    int scrapCountExpected = 2; //Number of notes expected
+    String pageUrl = "https://www.naver.com";
+
+    int scrapCountExpected = 2;
 
     @Test
     void should_return_success_When_existent_member_deletes_one_scrap() {
@@ -69,10 +86,30 @@ public class ScrapServiceTest {
         // 첫번째 스크랩에 메모를 2개 작성 했을 때,작성한 메모가 모두 조회되는지 확인
         //given
         //when
-        Slice<GetScrapResponse> getScrapResponses = scrapService.getScraps(email, PageRequest.of(0, 10));
+        Slice<GetScrapResponse> getScrapResponses = scrapService.getScraps(email,
+                PageRequest.of(0, 10));
         int memoCount = getScrapResponses.getContent().get(0).getMemoList().size();
 
         //then
-        assertEquals( memoCount, scrapCountExpected);
+        assertEquals(memoCount, scrapCountExpected);
+    }
+
+    @Test
+    void should_other_type_of_scrap_is_saved_When_webClientService_crawlingItem_returns_null() throws ParseException {
+        // webClientService.crawlingItem()이 null을 반환할 때, Other 타입의 Scrap이 저장되는지 확인
+        //given
+        memoRepository.deleteAll();
+        scrapRepository.deleteAll();
+
+        BDDMockito.when(webClientService.crawlingItem("http://localhost:123", pageUrl))
+                .thenReturn(null);
+
+        User user = userRepository.findById(1L).get();
+
+        //when
+        //then
+        assertThat(scrapService.saveScraps(user, pageUrl)).isInstanceOf(Other.class);
+        assertThat(scrapRepository.findByPageUrlAndUserAndDeletedDateIsNull(pageUrl, user)
+                .isPresent()).isTrue();
     }
 }


### PR DESCRIPTION
## 개요
- DAD-763

## 작업사항
- 장소 스크랩 저장 기능 구현
- 장소 스크랩 저장 테스트 코드 작성
- webClient 반환 타입을 Map.class에서 WebClientResponse.class(DTO)으로 변경
  - ObjectMapper에서 DTO의 속성값으로 자동 변환해주어 toString()할 필요가 없으므로 null 처리 관련 코드 제거
- mockWebServer 사용하여, webClientService 테스트 코드 작성
- 크롤링 서버가 비정상적인 응답(4xx, 5xx 에러 코드 및 응답 바디 값이 없는 경우)할 경우, other 스크랩으로 저장되도록 로직 수정

## 참고 자료
- mockWebServer (외부 API 호출 WebClient 테스트 서버) : https://www.devkuma.com/docs/mock-web-server/
- webClient 에러 처리 : https://dkswnkk.tistory.com/708
- webClient 반환 타입 변경 : https://thalals.tistory.com/379