### PR TITLE
[DAD-831] feat: 단 건의 메모 삭제 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/MemoController.java
+++ b/src/main/java/com/forever/dadamda/controller/MemoController.java
@@ -5,12 +5,14 @@ import com.forever.dadamda.dto.memo.CreateHighlightRequest;
 import com.forever.dadamda.dto.memo.CreateHighlightResponse;
 import com.forever.dadamda.dto.memo.CreateMemoRequest;
 import com.forever.dadamda.dto.memo.DeleteMemoRequest;
+import com.forever.dadamda.dto.memo.UpdateMemoRequest;
 import com.forever.dadamda.service.MemoService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -51,6 +53,16 @@ public class MemoController {
             Authentication authentication) {
         String email = authentication.getName();
         memoService.deleteMemo(email, deleteMemoRequest);
+        return ApiResponse.success();
+    }
+
+    @Operation(summary = "메모 수정", description = "단 건의 메모를 수정합니다.")
+    @PatchMapping("/v1/scraps/memo")
+    public ApiResponse<String> updateMemo(
+            @Valid @RequestBody UpdateMemoRequest updateMemoRequest,
+            Authentication authentication) {
+        String email = authentication.getName();
+        memoService.updateMemo(email, updateMemoRequest);
         return ApiResponse.success();
     }
 }

--- a/src/main/java/com/forever/dadamda/controller/MemoController.java
+++ b/src/main/java/com/forever/dadamda/controller/MemoController.java
@@ -4,11 +4,13 @@ import com.forever.dadamda.dto.ApiResponse;
 import com.forever.dadamda.dto.memo.CreateHighlightRequest;
 import com.forever.dadamda.dto.memo.CreateHighlightResponse;
 import com.forever.dadamda.dto.memo.CreateMemoRequest;
+import com.forever.dadamda.dto.memo.DeleteMemoRequest;
 import com.forever.dadamda.service.MemoService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,5 +42,15 @@ public class MemoController {
         CreateHighlightResponse createHighlightResponse = memoService.createHighlights(email,
                 createHighlightRequest);
         return ApiResponse.success(createHighlightResponse);
+    }
+
+    @Operation(summary = "1개 메모 삭제", description = "단 건의 메모를 삭제합니다.")
+    @DeleteMapping("/v1/scraps/memo")
+    public ApiResponse deleteMemo(
+            @Valid @RequestBody DeleteMemoRequest deleteMemoRequest,
+            Authentication authentication) {
+        String email = authentication.getName();
+        memoService.deleteMemo(email, deleteMemoRequest);
+        return ApiResponse.success();
     }
 }

--- a/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
@@ -6,7 +6,6 @@ import com.forever.dadamda.dto.scrap.CreateScrapResponse;
 import com.forever.dadamda.dto.scrap.GetScrapCountResponse;
 import com.forever.dadamda.dto.scrap.GetScrapResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
-import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.service.MemoService;
 import com.forever.dadamda.service.scrap.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,8 +66,7 @@ public class ScrapController {
             Authentication authentication) {
 
         String email = authentication.getName();
-        Scrap scrap = scrapService.updateScraps(email, updateScrapRequest);
-        memoService.updateMemos(scrap, updateScrapRequest.getMemoList());
+        scrapService.updateScraps(email, updateScrapRequest);
         return ApiResponse.success();
     }
 

--- a/src/main/java/com/forever/dadamda/dto/memo/DeleteMemoRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/memo/DeleteMemoRequest.java
@@ -1,0 +1,24 @@
+package com.forever.dadamda.dto.memo;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class DeleteMemoRequest {
+
+    @NotNull
+    @Positive(message = "scrapId는 1보다 커야 합니다.")
+    private Long scrapId;
+
+    @NotNull
+    @Positive(message = "memoId는 1보다 커야 합니다.")
+    private Long memoId;
+}

--- a/src/main/java/com/forever/dadamda/dto/memo/UpdateMemoRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/memo/UpdateMemoRequest.java
@@ -1,0 +1,28 @@
+package com.forever.dadamda.dto.memo;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateMemoRequest {
+
+    @NotNull
+    @Positive
+    private Long scrapId;
+
+    @NotNull
+    @Positive(message = "memoId는 1보다 커야 합니다.")
+    private Long memoId;
+
+    @NotBlank
+    private String memoText;
+}

--- a/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
@@ -1,8 +1,6 @@
 package com.forever.dadamda.dto.scrap;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.forever.dadamda.dto.memo.GetMemoResponse;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,7 +21,6 @@ public class UpdateScrapRequest {
     private String description;
     private String siteName;
     private String title;
-    private List<GetMemoResponse> memoList;
 
     // Article 부분
     private String author;

--- a/src/main/java/com/forever/dadamda/entity/Memo.java
+++ b/src/main/java/com/forever/dadamda/entity/Memo.java
@@ -39,8 +39,7 @@ public class Memo extends BaseTimeEntity {
         this.memoImageUrl = memoImageUrl;
     }
 
-    public void update(String memoText, String memoImageUrl){
+    public void update(String memoText){
         this.memoText = memoText;
-        this.memoImageUrl = memoImageUrl;
     }
 }

--- a/src/main/java/com/forever/dadamda/repository/MemoRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/MemoRepository.java
@@ -1,10 +1,13 @@
 package com.forever.dadamda.repository;
 
 import com.forever.dadamda.entity.Memo;
+import com.forever.dadamda.entity.scrap.Scrap;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
 
     Optional<Memo> findByIdAndDeletedDateIsNull(Long memoId);
+
+    Optional<Memo> findMemoByIdAndScrapAndDeletedDateIsNull(Long memoId, Scrap scrap);
 }

--- a/src/main/java/com/forever/dadamda/service/MemoService.java
+++ b/src/main/java/com/forever/dadamda/service/MemoService.java
@@ -4,6 +4,7 @@ import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.memo.CreateHighlightRequest;
 import com.forever.dadamda.dto.memo.CreateHighlightResponse;
 import com.forever.dadamda.dto.memo.CreateMemoRequest;
+import com.forever.dadamda.dto.memo.DeleteMemoRequest;
 import com.forever.dadamda.dto.memo.GetMemoResponse;
 import com.forever.dadamda.entity.Memo;
 import com.forever.dadamda.entity.scrap.Scrap;
@@ -97,5 +98,20 @@ public class MemoService {
                 memoRepository.save(memo);
             }
         }
+    }
+
+    @Transactional
+    public void deleteMemo(String email, DeleteMemoRequest deleteMemoRequest) {
+        User user = userService.validateUser(email);
+
+        Scrap scrap = scrapRepository.findByIdAndUserAndDeletedDateIsNull(
+                        deleteMemoRequest.getScrapId(), user)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+
+        Memo memo = memoRepository.findMemoByIdAndScrapAndDeletedDateIsNull(
+                        deleteMemoRequest.getMemoId(), scrap)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_MEMO));
+
+        memo.updateDeletedDate(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/forever/dadamda/service/MemoService.java
+++ b/src/main/java/com/forever/dadamda/service/MemoService.java
@@ -5,7 +5,7 @@ import com.forever.dadamda.dto.memo.CreateHighlightRequest;
 import com.forever.dadamda.dto.memo.CreateHighlightResponse;
 import com.forever.dadamda.dto.memo.CreateMemoRequest;
 import com.forever.dadamda.dto.memo.DeleteMemoRequest;
-import com.forever.dadamda.dto.memo.GetMemoResponse;
+import com.forever.dadamda.dto.memo.UpdateMemoRequest;
 import com.forever.dadamda.entity.Memo;
 import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.entity.user.User;
@@ -15,7 +15,6 @@ import com.forever.dadamda.repository.scrap.ScrapRepository;
 import com.forever.dadamda.service.scrap.ScrapService;
 import com.forever.dadamda.service.user.UserService;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.parser.ParseException;
 import org.springframework.stereotype.Service;
@@ -76,31 +75,6 @@ public class MemoService {
     }
 
     @Transactional
-    public void updateMemos(Scrap scrap, List<GetMemoResponse> getMemoResponseList) {
-        for (GetMemoResponse getMemoResponse : getMemoResponseList) {
-            if (getMemoResponse.getMemoId() > 0) {
-                Memo memo = memoRepository.findByIdAndDeletedDateIsNull(
-                        getMemoResponse.getMemoId()).orElseThrow(
-                        () -> new NotFoundException(ErrorCode.NOT_EXISTS_MEMO));
-
-                if (getMemoResponse.getMemoText() == null
-                        && getMemoResponse.getMemoImageUrl() == null) {
-                    memo.updateDeletedDate(LocalDateTime.now());
-                } else {
-                    memo.update(getMemoResponse.getMemoText(), getMemoResponse.getMemoImageUrl());
-                }
-            } else {
-                Memo memo = Memo.builder()
-                        .scrap(scrap)
-                        .memoText(getMemoResponse.getMemoText())
-                        .build();
-
-                memoRepository.save(memo);
-            }
-        }
-    }
-
-    @Transactional
     public void deleteMemo(String email, DeleteMemoRequest deleteMemoRequest) {
         User user = userService.validateUser(email);
 
@@ -113,5 +87,20 @@ public class MemoService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_MEMO));
 
         memo.updateDeletedDate(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void updateMemo(String email, UpdateMemoRequest updateMemoRequest) {
+        User user = userService.validateUser(email);
+
+        Scrap scrap = scrapRepository.findByIdAndUserAndDeletedDateIsNull(
+                        updateMemoRequest.getScrapId(), user)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+
+        Memo memo = memoRepository.findMemoByIdAndScrapAndDeletedDateIsNull(
+                        updateMemoRequest.getMemoId(), scrap)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_MEMO));
+
+        memo.update(updateMemoRequest.getMemoText());
     }
 }

--- a/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
@@ -42,7 +42,7 @@ public class ArticleService {
     }
 
     @Transactional
-    public Article updateArticle(User user, UpdateScrapRequest updateScrapRequest) {
+    public void updateArticle(User user, UpdateScrapRequest updateScrapRequest) {
         Article article = articleRepository.findByIdAndUserAndDeletedDateIsNull(
                         updateScrapRequest.getScrapId(), user)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
@@ -51,7 +51,6 @@ public class ArticleService {
         article.updateArticle(updateScrapRequest.getAuthor(),
                 updateScrapRequest.getBlogName());
 
-        return article;
     }
 
     @Transactional

--- a/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
@@ -37,13 +37,12 @@ public class OtherService {
     }
 
     @Transactional
-    public Other updateOther(User user, UpdateScrapRequest updateScrapRequest) {
+    public void updateOther(User user, UpdateScrapRequest updateScrapRequest) {
         Other other = otherRepository.findByIdAndUserAndDeletedDateIsNull(
                 updateScrapRequest.getScrapId(), user).orElseThrow(() -> new NotFoundException(
-                ErrorCode.NOT_EXISTS_SCRAP)); //동일한 함수가 3개 이상 반복되므로 validateScrap으로 함수 따로 빼기
+                ErrorCode.NOT_EXISTS_SCRAP));
         other.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
                 updateScrapRequest.getSiteName());
-        return other;
     }
 
     @Transactional

--- a/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
@@ -37,14 +37,13 @@ public class ProductService {
     }
 
     @Transactional
-    public Product updateProduct(User user, UpdateScrapRequest updateScrapRequest) {
+    public void updateProduct(User user, UpdateScrapRequest updateScrapRequest) {
         Product product = productRepository.findByIdAndUserAndDeletedDateIsNull(
                         updateScrapRequest.getScrapId(), user)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
         product.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
                 updateScrapRequest.getSiteName());
         product.updateProduct(updateScrapRequest.getPrice());
-        return product;
     }
 
     @Transactional

--- a/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
@@ -103,18 +103,21 @@ public class ScrapService {
     }
 
     @Transactional
-    public Scrap updateScraps(String email, UpdateScrapRequest updateScrapRequest) {
+    public void updateScraps(String email, UpdateScrapRequest updateScrapRequest) {
         User user = userService.validateUser(email);
 
         switch (updateScrapRequest.getDType()) {
             case "product":
-                return productService.updateProduct(user, updateScrapRequest);
+                productService.updateProduct(user, updateScrapRequest);
+                return;
             case "article":
-                return articleService.updateArticle(user, updateScrapRequest);
+                articleService.updateArticle(user, updateScrapRequest);
+                return;
             case "video":
-                return videoService.updateVideo(user, updateScrapRequest);
+                videoService.updateVideo(user, updateScrapRequest);
+                return;
             default:
-                return otherService.updateOther(user, updateScrapRequest);
+                otherService.updateOther(user, updateScrapRequest);
         }
     }
 

--- a/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
@@ -91,14 +91,13 @@ public class VideoService {
     }
 
     @Transactional
-    public Video updateVideo(User user, UpdateScrapRequest updateScrapRequest) {
+    public void updateVideo(User user, UpdateScrapRequest updateScrapRequest) {
         Video video = videoRepository.findByIdAndUserAndDeletedDateIsNull(
                         updateScrapRequest.getScrapId(), user)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
         video.update(updateScrapRequest.getTitle(), updateScrapRequest.getDescription(),
                 updateScrapRequest.getSiteName());
         video.updateVideo(updateScrapRequest.getChannelName());
-        return video;
     }
 
     @Transactional

--- a/src/test/java/com/forever/dadamda/controller/MemoControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/MemoControllerTest.java
@@ -1,9 +1,11 @@
 package com.forever.dadamda.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forever.dadamda.dto.memo.DeleteMemoRequest;
+import com.forever.dadamda.dto.memo.UpdateMemoRequest;
 import com.forever.dadamda.mock.WithCustomMockUser;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,5 +72,54 @@ public class MemoControllerTest {
                         .content(content)
                 )
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_it_return_400_error_When_modifying_memoText_to_blank()
+            throws Exception {
+        //memoText를 공백으로 수정할 때, 400 에러를 반환하는지 확인
+        //given
+        UpdateMemoRequest updateMemoRequest = UpdateMemoRequest.builder()
+                .memoText(" ")
+                .scrapId(1L)
+                .memoId(1L)
+                .build();
+        String content = objectMapper.writeValueAsString(updateMemoRequest);
+
+        //when
+        //then
+        String result = "{\"resultCode\":\"BR000\",\"message\":\"must not be blank\",\"data\":null}";
+
+        mockMvc.perform(patch("/v1/scraps/memo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                        .content(content)
+                )
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError())
+                .andExpect(MockMvcResultMatchers.content().string(result));
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_it_is_modified_normally_When_modifying_an_existing_memo()
+            throws Exception {
+        //존재하는 메모 수정할 때, 정상적으로 수정된다.
+        //given
+        UpdateMemoRequest updateMemoRequest = UpdateMemoRequest.builder()
+                .memoText("안녕하세요!")
+                .scrapId(1L)
+                .memoId(1L)
+                .build();
+
+        String content = objectMapper.writeValueAsString(updateMemoRequest);
+
+        //when
+        //then
+        mockMvc.perform(patch("/v1/scraps/memo")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-AUTH-TOKEN", "aaaaaaa")
+                .content(content)
+        ).andExpect(MockMvcResultMatchers.status().isOk());
     }
 }

--- a/src/test/java/com/forever/dadamda/controller/MemoControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/MemoControllerTest.java
@@ -1,0 +1,74 @@
+package com.forever.dadamda.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forever.dadamda.dto.memo.DeleteMemoRequest;
+import com.forever.dadamda.mock.WithCustomMockUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+public class MemoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithCustomMockUser
+    public void should_it_is_deleted_normally_When_deleting_an_existing_memo()
+            throws Exception {
+        //존재하는 메모 삭제할 때, 정상적으로 삭제된다.
+        //given
+        DeleteMemoRequest deleteMemoRequest = DeleteMemoRequest.builder()
+                .memoId(1L)
+                .scrapId(1L)
+                .build();
+        String content = objectMapper.writeValueAsString(deleteMemoRequest);
+
+        //when
+        //then
+        mockMvc.perform(delete("/v1/scraps/memo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                        .content(content)
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_it_return_400_error_When_deleting_notes_without_memoId()
+            throws Exception {
+        //memoId를 입력하지 않는 경우, 400 에러를 반환하는지 확인
+        //given
+        DeleteMemoRequest deleteMemoRequest = DeleteMemoRequest.builder()
+                .scrapId(1L)
+                .build();
+        String content = objectMapper.writeValueAsString(deleteMemoRequest);
+
+        //when
+        //then
+        mockMvc.perform(delete("/v1/scraps/memo")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                        .content(content)
+                )
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+}

--- a/src/test/java/com/forever/dadamda/service/MemoServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/MemoServiceTest.java
@@ -1,0 +1,57 @@
+package com.forever.dadamda.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.memo.DeleteMemoRequest;
+import com.forever.dadamda.exception.NotFoundException;
+import com.forever.dadamda.repository.MemoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+public class MemoServiceTest {
+
+    @Autowired
+    private MemoService memoService;
+
+    @Autowired
+    private MemoRepository memoRepository;
+
+    String existentEmail = "1234@naver.com";
+    String nonExistentEmail = "123@naver.com";
+
+    @Test
+    void should_NotFoundException_occurs_When_deleting_a_note_from_a_scrap_saved_by_another_person() {
+        // 다른 유저가 저장한 스크랩의 메모를 삭제할 때, NotFoundException(NOT_EXISTS_SCRAP) 예외가 발생한다.
+        DeleteMemoRequest deleteMemoRequest = DeleteMemoRequest.builder().memoId(1L).scrapId(1L)
+                .build();
+
+        //when
+        //then
+        assertThatThrownBy(
+                () -> memoService.deleteMemo(nonExistentEmail, deleteMemoRequest)).hasSameClassAs(
+                new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+    }
+
+    @Test
+    void should_the_deleted_date_of_the_note_becomes_not_null_When_deleting_a_note() {
+        // 스크랩의 메모를 삭제할 때, deleted_date가 업데이트된다.
+        DeleteMemoRequest deleteMemoRequest = DeleteMemoRequest.builder().memoId(1L).scrapId(1L)
+                .build();
+
+        //when
+        memoService.deleteMemo(existentEmail, deleteMemoRequest);
+
+        //then
+        assertThat((memoRepository.findById(1L)).get().getDeletedDate()).isNotNull();
+    }
+}

--- a/src/test/java/com/forever/dadamda/service/MemoServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/MemoServiceTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.memo.DeleteMemoRequest;
+import com.forever.dadamda.dto.memo.UpdateMemoRequest;
+import com.forever.dadamda.entity.Memo;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.MemoRepository;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -53,5 +56,22 @@ public class MemoServiceTest {
 
         //then
         assertThat((memoRepository.findById(1L)).get().getDeletedDate()).isNotNull();
+    }
+
+    @Test
+    void should_update_date_and_memo_text_are_updated_becomes_not_null_When_modifying_a_note() {
+        // 스크랩의 메모를 수정할 때, update_date와 memo_text가 업데이트된다.
+        UpdateMemoRequest updateMemoRequest = UpdateMemoRequest.builder().memoText("안녕하세요!")
+                .scrapId(1L).memoId(1L).build();
+
+        //when
+        memoService.updateMemo(existentEmail, updateMemoRequest);
+
+        //then
+        LocalDateTime memoPreviousUpdateDate = LocalDateTime.of(2023, 1, 1, 11, 11, 1);
+
+        Memo memo = (memoRepository.findById(1L)).get();
+        assertThat(memo.getModifiedDate()).isAfter(memoPreviousUpdateDate);
+        assertThat(memo.getMemoText()).isEqualTo("안녕하세요!");
     }
 }


### PR DESCRIPTION
## 개요
- DAD-831

## 작업사항
- 단 건의 메모 삭제 구현
- 단 건의 수정 기능 구현
- 단 건의 메모 삭제, 수정 기능 테스트 코드

## 변경로직(Optional)
- 기존의 스크랩 수정에서 메모 수정 가능했던 로직에서 메모 수정 안하는 로직으로 변경
- 메모 수정시 메모 텍스트만 수정 가능(메모 이미지는 수정안됨) + (허용하지 않는 것 : null, "", " " -> 공백도 허용 안함)
- 메모 삭제 및 수정 시, 스크랩 id와 메모 id를 동시에 보내주어야 함 (그래야지 해당 메모가 해당 유저가 작성한 메모인지 파악할 수 있고, 다른 유저가 삭제하거나 수정하지 못하게 할 수 있음)
-> 메모 table에는 유저 정보가 없고 스크랩 id만 있어서 스크랩 id로 유저 정보를 가져와야 함