### PR TITLE
[DAD-833] fix: 스크랩 저장시 에러가 없다면, 해당 카테고리의 스크랩이 1개만 저장되도록 문법 오류 수정

### DIFF
--- a/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/webClient/WebClientBodyResponse.java
@@ -55,13 +55,15 @@ public class WebClientBodyResponse {
     private String category;
 
     @Builder
-    public WebClientBodyResponse(String pageUrl, String title, String address, BigDecimal latitude,
-            BigDecimal longitude, String phoneNumber) {
+    public WebClientBodyResponse(String type, String pageUrl, String title, String address, BigDecimal latitude,
+            BigDecimal longitude, String phoneNumber, Long publishedDate) {
+        this.type = type;
         this.pageUrl = pageUrl;
         this.address = address;
         this.title = title;
         this.latitude = latitude;
         this.longitude = longitude;
         this.phoneNumber = phoneNumber;
+        this.publishedDate = publishedDate;
     }
 }

--- a/src/main/java/com/forever/dadamda/service/TimeService.java
+++ b/src/main/java/com/forever/dadamda/service/TimeService.java
@@ -3,12 +3,14 @@ package com.forever.dadamda.service;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Service;
 
 @Service
 public class TimeService{
-    public static LocalDateTime fromUnixTime(long unixTime) {
+    public static LocalDateTime fromUnixTime(Long unixTime) {
+        if(unixTime == null) {
+            return null;
+        }
         return LocalDateTime.ofInstant(Instant.ofEpochSecond(unixTime), ZoneOffset.UTC);
     }
 

--- a/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ScrapService.java
@@ -75,7 +75,7 @@ public class ScrapService {
                             return otherService.saveOther(response, user, pageUrl);
                     }
                 })
-                .orElse(otherService.saveOther(new WebClientBodyResponse(), user, pageUrl));
+                .orElseGet(() -> otherService.saveOther(new WebClientBodyResponse(), user, pageUrl));
     }
 
     @Transactional

--- a/src/test/java/com/forever/dadamda/service/scrap/ScrapServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/scrap/ScrapServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.forever.dadamda.dto.scrap.GetScrapResponse;
+import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
+import com.forever.dadamda.entity.scrap.Article;
 import com.forever.dadamda.entity.scrap.Other;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
@@ -111,5 +113,27 @@ public class ScrapServiceTest {
         assertThat(scrapService.saveScraps(user, pageUrl)).isInstanceOf(Other.class);
         assertThat(scrapRepository.findByPageUrlAndUserAndDeletedDateIsNull(pageUrl, user)
                 .isPresent()).isTrue();
+    }
+
+    @Test
+    void should_one_article_scrap_is_saved_When_webClientService_crawlingItem_returns_article() throws ParseException {
+        //given
+        memoRepository.deleteAll();
+        scrapRepository.deleteAll();
+
+        WebClientBodyResponse webClientBodyResponse = new WebClientBodyResponse().builder()
+                .title("title")
+                .type("article")
+                .build();
+
+        BDDMockito.when(webClientService.crawlingItem("test", pageUrl))
+                .thenReturn(webClientBodyResponse);
+
+        User user = userRepository.findById(1L).get();
+
+        //when
+        //then
+        assertThat(scrapService.saveScraps(user, pageUrl)).isInstanceOf(Article.class);
+        assertThat(scrapRepository.count()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## 개요
- DAD-833

## 작업사항
- 스크랩 저장시 에러가 없다면, 해당 카테고리의 스크랩이 1개만 저장되도록 문법 오류 수정 + 테스트 코드 작성
- fromUnixTime이 null인 경우 null 에러가 아닌 null을 반환하도록 수정 

## 해당 내용 블로그 작성
- https://velog.io/@da_na/Error-Java-Optional-문법-오류로-인한-에러-발생-해결-과정