### PR TITLE
[DAD-869] feat: 카테고리별 검색 기능 QueryDSL로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -119,11 +120,4 @@ sourceSets {
 
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/com/forever/dadamda/controller/scrap/ArticleController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/ArticleController.java
@@ -5,14 +5,17 @@ import com.forever.dadamda.dto.scrap.article.GetArticleCountResponse;
 import com.forever.dadamda.dto.scrap.article.GetArticleResponse;
 import com.forever.dadamda.service.scrap.ArticleService;
 import io.swagger.v3.oas.annotations.Operation;
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RequiredArgsConstructor
 @RestController
 public class ArticleController {
@@ -40,7 +43,7 @@ public class ArticleController {
     @Operation(summary = "아티클 스크랩 검색", description = "타이틀과 설명의 키워드로 아티클 스크랩을 검색할 수 있습니다.")
     @GetMapping("/v1/scraps/articles/search")
     public ApiResponse<Slice<GetArticleResponse>> searchArticles(
-            @RequestParam("keyword") String keyword,
+            @RequestParam("keyword") @NotBlank String keyword,
             Pageable pageable,
             Authentication authentication) {
 

--- a/src/main/java/com/forever/dadamda/controller/scrap/OtherController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/OtherController.java
@@ -5,14 +5,17 @@ import com.forever.dadamda.dto.scrap.other.GetOtherCountResponse;
 import com.forever.dadamda.dto.scrap.other.GetOtherResponse;
 import com.forever.dadamda.service.scrap.OtherService;
 import io.swagger.v3.oas.annotations.Operation;
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RequiredArgsConstructor
 @RestController
 public class OtherController {
@@ -38,8 +41,8 @@ public class OtherController {
 
     @Operation(summary = "기타 스크랩 검색", description = "타이틀과 설명의 키워드로 기타 스크랩을 검색할 수 있습니다.")
     @GetMapping("/v1/scraps/others/search")
-    public ApiResponse<Slice<GetOtherResponse>> searchArticles(
-            @RequestParam("keyword") String keyword,
+    public ApiResponse<Slice<GetOtherResponse>> searchOthers(
+            @RequestParam("keyword") @NotBlank String keyword,
             Pageable pageable,
             Authentication authentication) {
 

--- a/src/main/java/com/forever/dadamda/controller/scrap/ProductController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/ProductController.java
@@ -5,14 +5,17 @@ import com.forever.dadamda.dto.scrap.product.GetProductCountResponse;
 import com.forever.dadamda.dto.scrap.product.GetProductResponse;
 import com.forever.dadamda.service.scrap.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RequiredArgsConstructor
 @RestController
 public class ProductController {
@@ -40,7 +43,7 @@ public class ProductController {
     @Operation(summary = "상품 스크랩 검색", description = "타이틀과 설명의 키워드로 상품 스크랩을 검색할 수 있습니다.")
     @GetMapping("/v1/scraps/products/search")
     public ApiResponse<Slice<GetProductResponse>> searchProducts(
-            @RequestParam("keyword") String keyword,
+            @RequestParam("keyword") @NotBlank String keyword,
             Pageable pageable,
             Authentication authentication) {
 

--- a/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
@@ -6,17 +6,19 @@ import com.forever.dadamda.dto.scrap.CreateScrapResponse;
 import com.forever.dadamda.dto.scrap.GetScrapCountResponse;
 import com.forever.dadamda.dto.scrap.GetScrapResponse;
 import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
-import com.forever.dadamda.exception.InvalidException;
 import com.forever.dadamda.service.scrap.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
+import javax.validation.constraints.NotBlank;
 import org.springframework.data.domain.Pageable;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.minidev.json.parser.ParseException;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RequiredArgsConstructor
 @RestController
 public class ScrapController {
@@ -79,13 +81,10 @@ public class ScrapController {
     @Operation(summary = "스크랩 검색", description = "스크랩을 검색할 수 있습니다.")
     @GetMapping("/v1/scraps/search")
     public ApiResponse<Slice<GetScrapResponse>> searchScraps(
-            @RequestParam("keyword") String keyword,
+            @RequestParam("keyword") @NotBlank String keyword,
             Pageable pageable,
             Authentication authentication) {
 
-        if(keyword.isBlank()) {
-            throw new InvalidException("검색어를 입력해주세요.");
-        }
         String email = authentication.getName();
 
         return ApiResponse.success(scrapService.searchScraps(email, keyword, pageable));

--- a/src/main/java/com/forever/dadamda/controller/scrap/VideoController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/VideoController.java
@@ -5,14 +5,17 @@ import com.forever.dadamda.dto.scrap.video.GetVideoCountResponse;
 import com.forever.dadamda.dto.scrap.video.GetVideoResponse;
 import com.forever.dadamda.service.scrap.VideoService;
 import io.swagger.v3.oas.annotations.Operation;
+import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RequiredArgsConstructor
 @RestController
 public class VideoController {
@@ -38,8 +41,8 @@ public class VideoController {
 
     @Operation(summary = "비디오 스크랩 검색", description = "타이틀과 설명의 키워드로 비디오 스크랩을 검색할 수 있습니다.")
     @GetMapping("/v1/scraps/videos/search")
-    public ApiResponse<Slice<GetVideoResponse>> searchProducts(
-            @RequestParam("keyword") String keyword,
+    public ApiResponse<Slice<GetVideoResponse>> searchVideos(
+            @RequestParam("keyword") @NotBlank String keyword,
             Pageable pageable,
             Authentication authentication) {
 

--- a/src/main/java/com/forever/dadamda/exception/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/forever/dadamda/exception/advice/ControllerExceptionAdvice.java
@@ -8,6 +8,7 @@ import com.forever.dadamda.exception.InternalServerException;
 import com.forever.dadamda.exception.InvalidException;
 import com.forever.dadamda.exception.NotFoundException;
 import io.sentry.Sentry;
+import javax.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,14 @@ public class ControllerExceptionAdvice {
         String errorMessage = e.getBindingResult().getFieldErrors().stream()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .collect(joining("\n"));
+        Sentry.captureException(e);
+        return ApiResponse.error(ErrorCode.INVALID, errorMessage);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ConstraintViolationException.class)
+    private ApiResponse<Object> handleValidationParameterError(ConstraintViolationException e) {
+        String errorMessage = e.getMessage();
         Sentry.captureException(e);
         return ApiResponse.error(ErrorCode.INVALID, errorMessage);
     }

--- a/src/main/java/com/forever/dadamda/repository/scrap/ScrapRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/ScrapRepositoryCustomImpl.java
@@ -12,7 +12,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 @RequiredArgsConstructor
-public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
+public class ScrapRepositoryCustomImpl implements ScrapRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/forever/dadamda/repository/scrap/ScrapRepositoryImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/ScrapRepositoryImpl.java
@@ -4,13 +4,12 @@ import static com.forever.dadamda.entity.scrap.QScrap.scrap;
 
 import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.entity.user.User;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.data.domain.SliceImpl;
 
 @RequiredArgsConstructor
 public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
@@ -29,15 +28,18 @@ public class ScrapRepositoryImpl implements ScrapRepositoryCustom {
                                         .or(scrap.description.containsIgnoreCase(keyword)))
                 )
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(pageable.getPageSize()+1)
                 .orderBy(scrap.createdDate.desc())
                 .fetch();
 
-        JPAQuery<Long> count = queryFactory.query()
-                .from(scrap)
-                .select(scrap.count())
-                .where(scrap.user.eq(user));
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
 
-        return PageableExecutionUtils.getPage(contents, pageable, count::fetchOne);
+    private boolean hasNextPage(List<Scrap> contents, int pageSize) {
+        if (contents.size() > pageSize) {
+            contents.remove(pageSize);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepository.java
@@ -7,13 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends JpaRepository<Article, Long>, ArticleRepositoryCustom {
 
     Optional<Slice<Article>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
 
     Optional<Article> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 
     Long countByUserAndDeletedDateIsNull(User user);
-
-    Optional<Slice<Article>> findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(User user, String title, String description, Pageable pageable);
 }

--- a/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepository.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.repository.scrap;
+package com.forever.dadamda.repository.scrap.article;
 
 import com.forever.dadamda.entity.scrap.Article;
 import com.forever.dadamda.entity.user.User;

--- a/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepositoryCustom.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.forever.dadamda.repository.scrap.article;
+
+import com.forever.dadamda.entity.scrap.Article;
+import com.forever.dadamda.entity.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ArticleRepositoryCustom {
+
+    Slice<Article> searchKeywordInArticleOrderByCreatedDateDesc(
+            User user, String keyword, Pageable pageable);
+
+}

--- a/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/article/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package com.forever.dadamda.repository.scrap.article;
+
+import static com.forever.dadamda.entity.scrap.QArticle.article;
+
+import com.forever.dadamda.entity.scrap.Article;
+import com.forever.dadamda.entity.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Article> searchKeywordInArticleOrderByCreatedDateDesc(User user, String keyword,
+            Pageable pageable) {
+        List<Article> contents = queryFactory
+                .selectFrom(article)
+                .where(
+                        article.user.eq(user)
+                                .and(article.deletedDate.isNull())
+                                .and(article.title.containsIgnoreCase(keyword)
+                                        .or(article.description.containsIgnoreCase(keyword)))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize()+1)
+                .orderBy(article.createdDate.desc())
+                .fetch();
+
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
+
+    private boolean hasNextPage(List<Article> contents, int pageSize) {
+        if (contents.size() > pageSize) {
+            contents.remove(pageSize);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepository.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.repository.scrap;
+package com.forever.dadamda.repository.scrap.other;
 
 import com.forever.dadamda.entity.scrap.Other;
 import com.forever.dadamda.entity.user.User;

--- a/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepository.java
@@ -7,13 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OtherRepository extends JpaRepository<Other, Long> {
+public interface OtherRepository extends JpaRepository<Other, Long>, OtherRepositoryCustom {
 
     Optional<Slice<Other>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
 
     Optional<Other> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 
     Long countByUserAndDeletedDateIsNull(User user);
-
-    Optional<Slice<Other>> findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(User user, String title, String description, Pageable pageable);
 }

--- a/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepositoryCustom.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.forever.dadamda.repository.scrap.other;
+
+import com.forever.dadamda.entity.scrap.Other;
+import com.forever.dadamda.entity.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface OtherRepositoryCustom {
+
+    Slice<Other> searchKeywordInOtherOrderByCreatedDateDesc(
+            User user, String keyword, Pageable pageable);
+
+}

--- a/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/other/OtherRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package com.forever.dadamda.repository.scrap.other;
+
+import static com.forever.dadamda.entity.scrap.QOther.other;
+
+import com.forever.dadamda.entity.scrap.Other;
+import com.forever.dadamda.entity.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class OtherRepositoryCustomImpl implements OtherRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Other> searchKeywordInOtherOrderByCreatedDateDesc(User user, String keyword,
+            Pageable pageable) {
+        List<Other> contents = queryFactory
+                .selectFrom(other)
+                .where(
+                        other.user.eq(user)
+                                .and(other.deletedDate.isNull())
+                                .and(other.title.containsIgnoreCase(keyword)
+                                        .or(other.description.containsIgnoreCase(keyword)))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(other.createdDate.desc())
+                .fetch();
+
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
+
+    private boolean hasNextPage(List<Other> contents, int pageSize) {
+        if (contents.size() > pageSize) {
+            contents.remove(pageSize);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/forever/dadamda/repository/scrap/place/PlaceRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/place/PlaceRepository.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.repository.scrap;
+package com.forever.dadamda.repository.scrap.place;
 
 import com.forever.dadamda.entity.scrap.Place;
 import com.forever.dadamda.entity.user.User;

--- a/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepository.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.repository.scrap;
+package com.forever.dadamda.repository.scrap.product;
 
 import com.forever.dadamda.entity.scrap.Product;
 import com.forever.dadamda.entity.user.User;

--- a/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepository.java
@@ -7,13 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
     Optional<Slice<Product>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
 
     Optional<Product> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 
     Long countByUserAndDeletedDateIsNull(User user);
-
-    Optional<Slice<Product>> findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(User user, String title, String description, Pageable pageable);
 }

--- a/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepositoryCustom.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.forever.dadamda.repository.scrap.product;
+
+import com.forever.dadamda.entity.scrap.Product;
+import com.forever.dadamda.entity.scrap.Scrap;
+import com.forever.dadamda.entity.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface ProductRepositoryCustom {
+
+    Slice<Product> searchKeywordInProductOrderByCreatedDateDesc(
+            User user, String keyword, Pageable pageable);
+
+}

--- a/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/product/ProductRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package com.forever.dadamda.repository.scrap.product;
+
+import static com.forever.dadamda.entity.scrap.QProduct.product;
+
+import com.forever.dadamda.entity.scrap.Product;
+import com.forever.dadamda.entity.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Product> searchKeywordInProductOrderByCreatedDateDesc(User user, String keyword,
+            Pageable pageable) {
+        List<Product> contents = queryFactory
+                .selectFrom(product)
+                .where(
+                        product.user.eq(user)
+                                .and(product.deletedDate.isNull())
+                                .and(product.title.containsIgnoreCase(keyword)
+                                        .or(product.description.containsIgnoreCase(keyword)))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(product.createdDate.desc())
+                .fetch();
+
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
+
+    private boolean hasNextPage(List<Product> contents, int pageSize) {
+        if (contents.size() > pageSize) {
+            contents.remove(pageSize);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepository.java
@@ -7,13 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface VideoRepository extends JpaRepository<Video, Long> {
+public interface VideoRepository extends JpaRepository<Video, Long>, VideoRepositoryCustom {
 
     Optional<Slice<Video>> findAllByUserAndDeletedDateIsNull(User user, Pageable pageable);
 
     Optional<Video> findByIdAndUserAndDeletedDateIsNull(Long scrapId, User user);
 
     Long countByUserAndDeletedDateIsNull(User user);
-
-    Optional<Slice<Video>> findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(User user, String title, String description, Pageable pageable);
 }

--- a/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepository.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.repository.scrap;
+package com.forever.dadamda.repository.scrap.video;
 
 import com.forever.dadamda.entity.scrap.Video;
 import com.forever.dadamda.entity.user.User;

--- a/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepositoryCustom.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.forever.dadamda.repository.scrap.video;
+
+import com.forever.dadamda.entity.scrap.Video;
+import com.forever.dadamda.entity.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface VideoRepositoryCustom {
+
+    Slice<Video> searchKeywordInVideoOrderByCreatedDateDesc(
+            User user, String keyword, Pageable pageable);
+}

--- a/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/scrap/video/VideoRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package com.forever.dadamda.repository.scrap.video;
+
+import static com.forever.dadamda.entity.scrap.QVideo.video;
+
+import com.forever.dadamda.entity.scrap.Video;
+import com.forever.dadamda.entity.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class VideoRepositoryCustomImpl implements VideoRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Video> searchKeywordInVideoOrderByCreatedDateDesc(User user, String keyword,
+            Pageable pageable) {
+        List<Video> contents = queryFactory
+                .selectFrom(video)
+                .where(
+                        video.user.eq(user)
+                                .and(video.deletedDate.isNull())
+                                .and(video.title.containsIgnoreCase(keyword)
+                                        .or(video.description.containsIgnoreCase(keyword)))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(video.createdDate.desc())
+                .fetch();
+
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
+
+    private boolean hasNextPage(List<Video> contents, int pageSize) {
+        if (contents.size() > pageSize) {
+            contents.remove(pageSize);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
@@ -78,14 +78,8 @@ public class ArticleService {
             Pageable pageable) {
         User user = userService.validateUser(email);
 
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Article> scrapSlice = articleRepository
-                .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageRequest)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+        Slice<Article> scrapSlice = articleRepository.searchKeywordInArticleOrderByCreatedDateDesc(
+                user, keyword, pageable);
 
         return scrapSlice.map(GetArticleResponse::of);
     }

--- a/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ArticleService.java
@@ -7,7 +7,7 @@ import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Article;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
-import com.forever.dadamda.repository.scrap.ArticleRepository;
+import com.forever.dadamda.repository.scrap.article.ArticleRepository;
 import com.forever.dadamda.service.TimeService;
 import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
@@ -69,14 +69,8 @@ public class OtherService {
     public Slice<GetOtherResponse> searchOthers(String email, String keyword, Pageable pageable) {
         User user = userService.validateUser(email);
 
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Other> otherSlice = otherRepository
-                .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageRequest)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+        Slice<Other> otherSlice = otherRepository.searchKeywordInOtherOrderByCreatedDateDesc(user,
+                keyword, pageable);
 
         return otherSlice.map(GetOtherResponse::of);
     }

--- a/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/OtherService.java
@@ -7,7 +7,7 @@ import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Other;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
-import com.forever.dadamda.repository.scrap.OtherRepository;
+import com.forever.dadamda.repository.scrap.other.OtherRepository;
 import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/PlaceService.java
@@ -6,7 +6,7 @@ import com.forever.dadamda.dto.scrap.place.GetPlaceResponse;
 import com.forever.dadamda.entity.scrap.Place;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
-import com.forever.dadamda.repository.scrap.PlaceRepository;
+import com.forever.dadamda.repository.scrap.place.PlaceRepository;
 import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
@@ -7,7 +7,7 @@ import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Product;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
-import com.forever.dadamda.repository.scrap.ProductRepository;
+import com.forever.dadamda.repository.scrap.product.ProductRepository;
 import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/ProductService.java
@@ -67,17 +67,12 @@ public class ProductService {
     }
 
     @Transactional
-    public Slice<GetProductResponse> searchProducts(String email, String keyword, Pageable pageable) {
+    public Slice<GetProductResponse> searchProducts(String email, String keyword,
+            Pageable pageable) {
         User user = userService.validateUser(email);
 
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Product> scrapSlice = productRepository
-                .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageRequest)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+        Slice<Product> scrapSlice = productRepository.searchKeywordInProductOrderByCreatedDateDesc(
+                user, keyword, pageable);
 
         return scrapSlice.map(GetProductResponse::of);
     }

--- a/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
@@ -7,7 +7,7 @@ import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.entity.scrap.Video;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
-import com.forever.dadamda.repository.scrap.VideoRepository;
+import com.forever.dadamda.repository.scrap.video.VideoRepository;
 import com.forever.dadamda.service.TimeService;
 import com.forever.dadamda.service.user.UserService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
+++ b/src/main/java/com/forever/dadamda/service/scrap/VideoService.java
@@ -124,14 +124,8 @@ public class VideoService {
     public Slice<GetVideoResponse> searchVideos(String email, String keyword, Pageable pageable) {
         User user = userService.validateUser(email);
 
-        Sort sort = Sort.by(Sort.Direction.DESC, "createdDate");
-        PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                sort);
-
-        Slice<Video> scrapSlice = videoRepository
-                .findAllByUserAndDeletedDateIsNullAndTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                        user, keyword, keyword, pageRequest)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_SCRAP));
+        Slice<Video> scrapSlice = videoRepository.searchKeywordInVideoOrderByCreatedDateDesc(
+                user, keyword, pageable);
 
         return scrapSlice.map(GetVideoResponse::of);
     }

--- a/src/test/java/com/forever/dadamda/controller/scrap/VideoControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/scrap/VideoControllerTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.web.servlet.MockMvc;
@@ -17,9 +16,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-@Sql(scripts = "classpath:truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
-@Sql(scripts = "classpath:setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@TestPropertySource(locations = "classpath:application-test.yml")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public class VideoControllerTest {
 
     @Autowired
@@ -37,5 +35,18 @@ public class VideoControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("오늘의 일기 2"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].title").value("오늘의 일기 1"));
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_an_empty_array_is_returned_When_keyword_is_not_present() throws Exception {
+        //스크랩 검색할 때, 해당 키워드가 없을 때 빈 배열이 반환되는 지 확인
+        mockMvc.perform(get("/v1/scraps/videos/search")
+                        .param("keyword", "내일")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .header("X-AUTH-TOKEN", "aaaaaaa"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").doesNotExist());
     }
 }

--- a/src/test/java/com/forever/dadamda/repository/ScrapRepositoryTest.java
+++ b/src/test/java/com/forever/dadamda/repository/ScrapRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.forever.dadamda.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.forever.dadamda.entity.scrap.Scrap;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.repository.scrap.ScrapRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Import(TestConfig.class)
+public class ScrapRepositoryTest {
+
+    @Autowired
+    private ScrapRepository scrapRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    String email = "1234@naver.com";
+
+    @Test
+    void should_has_next_is_returned_when_the_next_page_is_present() {
+        // 다음 페이지가 있을 때, hasNext가 true로 반환된다.
+        // given
+        User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();
+        String keyword = "오늘";
+        Pageable pageable = PageRequest.of(0, 2);
+
+        //when
+        Slice<Scrap> results = scrapRepository.searchKeywordInScrapOrderByCreatedDateDesc(user,
+                keyword, pageable);
+
+        // then
+        assertThat(results.getSize()).isEqualByComparingTo(2);
+        assertThat(results.hasNext()).isTrue();
+    }
+}

--- a/src/test/java/com/forever/dadamda/repository/scrap/ArticleRepositoryTest.java
+++ b/src/test/java/com/forever/dadamda/repository/scrap/ArticleRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.forever.dadamda.repository.scrap;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.forever.dadamda.entity.scrap.Article;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.repository.TestConfig;
+import com.forever.dadamda.repository.UserRepository;
+import com.forever.dadamda.repository.scrap.article.ArticleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Import(TestConfig.class)
+public class ArticleRepositoryTest {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    String email = "1234@naver.com";
+
+    @Test
+    void should_the_title_is_returned_when_searching_for_keywords_without_case_insensitive() {
+        // 대소문자를 구분하지 않고 keyword를 검색할 때, 검색 결과가 있으면 해당 title을 반환된다.
+        //스크랩 검색할 때, 대소문자를 구분하지 않고 검색할 수 있는 지 확인
+        // given
+        User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();
+        String keyword = "toDay";
+        Pageable pageable = PageRequest.of(0, 2);
+
+        //when
+        Slice<Article> results = articleRepository.searchKeywordInArticleOrderByCreatedDateDesc(user,
+                keyword, pageable);
+
+        // then
+        assertThat(results.getContent().get(0).getDescription()).isEqualTo("Today is rainy");
+    }
+}

--- a/src/test/java/com/forever/dadamda/repository/scrap/OtherRepositoryTest.java
+++ b/src/test/java/com/forever/dadamda/repository/scrap/OtherRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.forever.dadamda.repository.scrap;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.forever.dadamda.entity.scrap.Other;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.repository.TestConfig;
+import com.forever.dadamda.repository.UserRepository;
+import com.forever.dadamda.repository.scrap.other.OtherRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Import(TestConfig.class)
+public class OtherRepositoryTest {
+
+    @Autowired
+    private OtherRepository otherRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    String email = "1234@naver.com";
+
+    @Test
+    void should_the_scrap_is_not_returned_when_searching_for_other_category_in_which_the_scrap_does_not_exist() {
+        // 스크랩이 존재하지 않을 때 검색하면, 스크랩이 반환되지 않는다.
+        // given
+        User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();
+        String keyword = "오늘";
+        Pageable pageable = PageRequest.of(0, 2);
+
+        //when
+        Slice<Other> results = otherRepository.searchKeywordInOtherOrderByCreatedDateDesc(user,
+                keyword, pageable);
+
+        // then
+        assertThat(results.getContent().size()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/forever/dadamda/repository/scrap/ProductRepositoryTest.java
+++ b/src/test/java/com/forever/dadamda/repository/scrap/ProductRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.forever.dadamda.repository.scrap;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.forever.dadamda.entity.scrap.Product;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.repository.TestConfig;
+import com.forever.dadamda.repository.UserRepository;
+import com.forever.dadamda.repository.scrap.product.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Import(TestConfig.class)
+public class ProductRepositoryTest {
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    String email = "1234@naver.com";
+
+    @Test
+    void should_memoList_from_the_scrap_are_also_returned_when_searching_for_keywords() {
+        // 키워드 검색할 때, 해당 스크랩의 메모도 같이 반환된다.
+        // given
+        User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();
+        String keyword = "coupang";
+        Pageable pageable = PageRequest.of(0, 2);
+
+        //when
+        Slice<Product> results = productRepository.searchKeywordInProductOrderByCreatedDateDesc(user,
+                keyword, pageable);
+
+        // then
+        assertThat(results.getContent().get(0).getMemoList().get(0).getMemoText()).isEqualTo("Hello 1");
+    }
+}

--- a/src/test/java/com/forever/dadamda/repository/scrap/ScrapRepositoryTest.java
+++ b/src/test/java/com/forever/dadamda/repository/scrap/ScrapRepositoryTest.java
@@ -1,10 +1,11 @@
-package com.forever.dadamda.repository;
+package com.forever.dadamda.repository.scrap;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.forever.dadamda.entity.scrap.Scrap;
 import com.forever.dadamda.entity.user.User;
-import com.forever.dadamda.repository.scrap.ScrapRepository;
+import com.forever.dadamda.repository.TestConfig;
+import com.forever.dadamda.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -32,7 +33,7 @@ public class ScrapRepositoryTest {
     String email = "1234@naver.com";
 
     @Test
-    void should_has_next_is_returned_when_the_next_page_is_present() {
+    void should_has_next_is_returned_true_when_the_next_page_is_present() {
         // 다음 페이지가 있을 때, hasNext가 true로 반환된다.
         // given
         User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();

--- a/src/test/java/com/forever/dadamda/repository/scrap/VideoRepositoryTest.java
+++ b/src/test/java/com/forever/dadamda/repository/scrap/VideoRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.forever.dadamda.repository.scrap;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.forever.dadamda.entity.scrap.Video;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.repository.TestConfig;
+import com.forever.dadamda.repository.UserRepository;
+import com.forever.dadamda.repository.scrap.video.VideoRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Import(TestConfig.class)
+public class VideoRepositoryTest {
+
+    @Autowired
+    private VideoRepository videoRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    String email = "1234@naver.com";
+
+    @Test
+    void should_has_next_is_returned_false_when_there_is_no_next_page() {
+        // 검색한 결과가 없을 때, hasNext가 false로 반환된다.
+        // given
+        User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();
+        String keyword = "내일";
+        Pageable pageable = PageRequest.of(0, 2);
+
+        // when
+        Slice<Video> results = videoRepository.searchKeywordInVideoOrderByCreatedDateDesc(user,
+                keyword, pageable);
+
+        // then
+        assertThat(results.hasNext()).isFalse();
+    }
+
+}

--- a/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/scrap/PlaceServiceTest.java
@@ -8,7 +8,7 @@ import com.forever.dadamda.dto.webClient.WebClientBodyResponse;
 import com.forever.dadamda.entity.scrap.Place;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.repository.UserRepository;
-import com.forever.dadamda.repository.scrap.PlaceRepository;
+import com.forever.dadamda.repository.scrap.place.PlaceRepository;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## 개요
- DAD-869

## 작업사항
- 카테고리별 검색 기능 QueryDSL로 변경 + 테스트 코드 작성
- 무한 스크롤 page방식에서 slice로 변경

## 변경로직(Optional)
- scrap repository 폴더를 각각의 카테고리 폴더로 변경