### PR TITLE
[DAD-901] fix: 카카오 로그인시, JWT 관련 문제 해결

### DIFF
--- a/src/main/java/com/forever/dadamda/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/forever/dadamda/handler/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.forever.dadamda.handler;
 
 import com.forever.dadamda.service.TokenService;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -27,6 +28,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
+
+        if(email == null) {
+            Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+            email = (String) kakaoAccount.get("email");
+        }
 
         String token = tokenService.generateToken(email, "USER");
         response.sendRedirect(LOGIN_REDIRECT_URL+token);


### PR DESCRIPTION
## 개요
- DAD-901

## 작업사항
- 카카오 로그인시, JWT 관련 문제 해결
- google과 카카오 oauth에서 전달 받는 json의 형태가 달라서 email을 가져오지 못하는 문제 발생하여 카카오 oauth의 json 형태에 맞는 로직 추가

## 관련 사진
![image](https://github.com/SWM-team-forever/dadamda-backend/assets/75533232/445864c7-0a4c-41bd-8aa1-7469b55740d8)