### PR TITLE
[DAD-883] feat: 유효성 검사 추가

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -5,6 +5,7 @@ import com.forever.dadamda.dto.board.CreateBoardRequest;
 import com.forever.dadamda.service.BoardService;
 import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -35,7 +36,7 @@ public class BoardController {
 
     @Operation(summary = "보드 삭제", description = "1개의 보드를 삭제합니다.")
     @DeleteMapping("/v1/boards/{boardId}")
-    public ApiResponse<String> createBoards(@PathVariable @Positive Long boardId,
+    public ApiResponse<String> createBoards(@PathVariable @Positive @NotNull Long boardId,
             Authentication authentication) {
         String email = authentication.getName();
         boardService.deleteBoards(email, boardId);
@@ -44,7 +45,7 @@ public class BoardController {
 
     @Operation(summary = "보드 고정", description = "1개의 보드를 보드 카테고리에서 상단에 고정합니다.")
     @PatchMapping("/v1/boards/fixed/{boardId}")
-    public ApiResponse<String> fixedBoards(@PathVariable @Positive Long boardId,
+    public ApiResponse<String> fixedBoards(@PathVariable @Positive @NotNull Long boardId,
             Authentication authentication) {
         String email = authentication.getName();
         boardService.fixedBoards(email, boardId);

--- a/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
@@ -63,7 +63,7 @@ public class ScrapController {
     @Operation(summary = "전체 스크랩 수정", description = "스크랩을 수정할 수 있습니다.")
     @PatchMapping("/v1/scraps")
     public ApiResponse<String> updateScraps(
-            @RequestBody UpdateScrapRequest updateScrapRequest,
+            @Valid @RequestBody UpdateScrapRequest updateScrapRequest,
             Authentication authentication) {
 
         String email = authentication.getName();

--- a/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
+++ b/src/main/java/com/forever/dadamda/controller/scrap/ScrapController.java
@@ -9,6 +9,8 @@ import com.forever.dadamda.dto.scrap.UpdateScrapRequest;
 import com.forever.dadamda.service.scrap.ScrapService;
 import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import org.springframework.data.domain.Pageable;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +42,7 @@ public class ScrapController {
 
     @Operation(summary = "스크랩 삭제", description = "한개의 스크랩을 삭제할 수 있습니다.")
     @DeleteMapping("/v1/scraps/{scrapId}")
-    public ApiResponse<String> deleteScraps(@Valid @PathVariable("scrapId") Long scrapId,
+    public ApiResponse<String> deleteScraps(@PathVariable("scrapId") @NotNull @Positive Long scrapId,
             Authentication authentication) {
 
         String email = authentication.getName();

--- a/src/main/java/com/forever/dadamda/dto/memo/CreateMemoRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/memo/CreateMemoRequest.java
@@ -1,5 +1,8 @@
 package com.forever.dadamda.dto.memo;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,8 +15,11 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateMemoRequest {
 
+    @NotNull(message = "scrapId를 입력해주세요.")
+    @Positive(message = "scrapId는 1보다 커야 합니다.")
     private Long scrapId;
 
+    @NotBlank(message = "메모를 입력해주세요.")
     @Size(max = 1000, message = "최대 1000자까지 선택할 수 있습니다.")
     private String memoText;
 }

--- a/src/main/java/com/forever/dadamda/dto/memo/UpdateMemoRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/memo/UpdateMemoRequest.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.dto.memo;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,13 +17,14 @@ import lombok.NoArgsConstructor;
 public class UpdateMemoRequest {
 
     @NotNull
-    @Positive
+    @Positive(message = "scrapId는 1보다 커야 합니다.")
     private Long scrapId;
 
     @NotNull
     @Positive(message = "memoId는 1보다 커야 합니다.")
     private Long memoId;
 
-    @NotBlank
+    @NotBlank(message = "메모를 입력해주세요.")
+    @Size(max = 1000, message = "최대 1000자까지 입력할 수 있습니다.")
     private String memoText;
 }

--- a/src/main/java/com/forever/dadamda/dto/scrap/SearchScrapRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/SearchScrapRequest.java
@@ -1,8 +1,0 @@
-package com.forever.dadamda.dto.scrap;
-
-import lombok.Getter;
-
-@Getter
-public class SearchScrapRequest {
-
-}

--- a/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
@@ -1,6 +1,7 @@
 package com.forever.dadamda.dto.scrap;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
@@ -20,7 +21,7 @@ public class UpdateScrapRequest {
     @Positive(message = "scrapId는 1보다 커야 합니다.")
     private Long scrapId;
 
-    @NotNull(message = "dType을 입력해주세요.")
+    @NotBlank(message = "dType을 입력해주세요.")
     @JsonProperty("dtype")
     private String dType;
 

--- a/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
@@ -1,6 +1,9 @@
 package com.forever.dadamda.dto.scrap;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,22 +16,34 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateScrapRequest {
     // 공통 부분
+    @NotNull(message = "scrapId를 입력해주세요.")
+    @Positive(message = "scrapId는 1보다 커야 합니다.")
     private Long scrapId;
 
     @JsonProperty("dtype")
     private String dType;
 
+    @Size(max = 1000, message = "최대 1000자까지 입력할 수 있습니다.")
     private String description;
+
+    @Size(max = 100, message = "최대 100자까지 입력할 수 있습니다.")
     private String siteName;
+
+    @Size(max = 200, message = "최대 200자까지 입력할 수 있습니다.")
     private String title;
 
     // Article 부분
+    @Size(max = 100, message = "최대 100자까지 입력할 수 있습니다.")
     private String author;
+
+    @Size(max = 100, message = "최대 100자까지 입력할 수 있습니다.")
     private String blogName;
 
     // Product 부분
+    @Size(max = 100, message = "최대 100자까지 입력할 수 있습니다.")
     private String price;
 
     // Video 부분
+    @Size(max = 100, message = "최대 100자까지 입력할 수 있습니다.")
     private String channelName;
 }

--- a/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/scrap/UpdateScrapRequest.java
@@ -20,6 +20,7 @@ public class UpdateScrapRequest {
     @Positive(message = "scrapId는 1보다 커야 합니다.")
     private Long scrapId;
 
+    @NotNull(message = "dType을 입력해주세요.")
     @JsonProperty("dtype")
     private String dType;
 

--- a/src/test/java/com/forever/dadamda/controller/MemoControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/MemoControllerTest.java
@@ -89,15 +89,12 @@ public class MemoControllerTest {
 
         //when
         //then
-        String result = "{\"resultCode\":\"BR000\",\"message\":\"must not be blank\",\"data\":null}";
-
         mockMvc.perform(patch("/v1/scraps/memo")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-AUTH-TOKEN", "aaaaaaa")
                         .content(content)
                 )
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError())
-                .andExpect(MockMvcResultMatchers.content().string(result));
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError());
     }
 
     @Test

--- a/src/test/java/com/forever/dadamda/controller/scrap/ScrapControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/scrap/ScrapControllerTest.java
@@ -1,5 +1,6 @@
 package com.forever.dadamda.controller.scrap;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
@@ -143,6 +144,33 @@ public class ScrapControllerTest {
         mockMvc.perform(patch("/v1/scraps")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(content)
+                        .header("X-AUTH-TOKEN", "aaaaaaa"))
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_scrap_is_deleted_successfully_When_deleting_scrap_with_positive_scrapId() throws Exception {
+        // siteName이 100자 초과일 때, 400 에러 발생
+        mockMvc.perform(delete("/v1/scraps/{scrapId}", 1L)
+                        .header("X-AUTH-TOKEN", "aaaaaaa"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_4xx_error_When_deleting_scrap_with_scrapId_null() throws Exception {
+        // scrapId가 null인 스크랩 삭제할 때, 400 에러 발생
+        mockMvc.perform(delete("/v1/scraps")
+                        .header("X-AUTH-TOKEN", "aaaaaaa"))
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_4xx_error_When_deleting_scrap_with_negative_scrapId() throws Exception {
+        // scrapId가 음수인 스크랩 삭제할 때, 400 에러 발생
+        mockMvc.perform(delete("/v1/scraps/{scrapId}", -1L)
                         .header("X-AUTH-TOKEN", "aaaaaaa"))
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError());
     }

--- a/src/test/java/com/forever/dadamda/controller/scrap/ScrapControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/scrap/ScrapControllerTest.java
@@ -173,6 +173,7 @@ public class ScrapControllerTest {
         mockMvc.perform(delete("/v1/scraps/{scrapId}", -1L)
                         .header("X-AUTH-TOKEN", "aaaaaaa"))
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
 
     @Test
     @WithCustomMockUser


### PR DESCRIPTION
## 개요
- DAD-883

## 작업사항
- 메모 생성 및 수정, 스크랩 수정 유효성 검사 추가
-  스크랩 삭제 scrapId 유효성 검사 추가
- 스크랩 수정, 보드 삭제, 고정에 대한 유효성 검사 추가
- 스크랩 수정, 삭제 유효성 검사 테스트 코드 작성

## 전체 유효성 검사
1. 스크랩 추가 (post, /v1/scraps)
    1. URL 형식인지
    2. 2083자까지 입력가능
    3. NotBlank : null, “”, “ “ 모두 허용하지 않음
2. 스크랩 삭제 (delete, /v1/scraps/{scrapId})
    1. scrapId가 양수인지
    2. scrapId가 Not null인지
3. 전체 카테고리에서 스크랩 수정
    1. scrapId가 NotNull이고, 양수인지
    2. dType가 NotBlank인지
    3. Description : 1000글자까지 입력 가능
    4. Sitename : 100글자까지 입력 가능
    5. Title : 200글자까지 입력 가능
    6. Author : 100글자까지 입력 가능
    7. blogName : 100글자까지 입력 가능
    8. Price : 100글자까지 입력 가능
    9. channelName : 100글자까지 입력 가능
4. 스크랩 검색
    1. keyword가 NokBlank인지
5. 보드 삭제 (/v1/boards/{boardId})
    1. boardId가 양수인지
    2. boardId가 notnull인지
6. 메모 추가
    1. scrapId가 양수이고, notnull인지
    2. memoText : NotBlank 인지, 최대 1000글자까지 입력 가능
7. 하이라이트 추가
    1. pageUrl : NotBlank인지, URL 형식인지, 2083글자까지 입력 가능
    2. selectedText : 1000글자까지 입력 가능
    3. selectedImageUrl : 2083글자까지 입력 가능, URL 형식인지 확인
8. 메모 삭제
    1. scrapId : not null, 양수인지
    2. memoId : not null, 양수인지
9. 메모 수정
    1. scrapId : not null, 양수인지
    2. memoId : not null, 양수인지
    3. memoText : not blank, 1000글자까지 입력 가능