### PR TITLE
[DAD-905] fix: oauth 로그인 url에 인증이 필요하도록 설정

### DIFF
--- a/src/main/java/com/forever/dadamda/config/SecurityConfig.java
+++ b/src/main/java/com/forever/dadamda/config/SecurityConfig.java
@@ -60,8 +60,9 @@ public class SecurityConfig {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/h2-console/**", "/actuator/**",
-                        "/", "/api-docs/**", "/swagger-ui/**").permitAll()
-                .antMatchers("/v1/**", "/login/**").hasRole(Role.USER.name())
+                        "/", "/api-docs/**", "/swagger-ui/**", "/oauth-login").permitAll()
+                .antMatchers("/oauth2/**").authenticated()
+                .antMatchers("/v1/**").hasRole(Role.USER.name())
                 .anyRequest().authenticated()
                 .and()
                 .logout()

--- a/src/main/java/com/forever/dadamda/controller/UserController.java
+++ b/src/main/java/com/forever/dadamda/controller/UserController.java
@@ -18,7 +18,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("")
+    @GetMapping("/oauth-login")
     public ApiResponse<String> login(@RequestParam String token) {
         return ApiResponse.success();
     }


### PR DESCRIPTION
## 개요
- DAD-905

## 작업사항
- oauth 로그인 url에 인증이 필요하도록 설정

## 참고 사진
- 최초 oauth 로그인시에 /login/oauth2/code/kakao 와 같이 oauth 인증 서버에서 받아오는 url을 spring security에서 거르지 못해서 오류가 발생함.
![image](https://github.com/SWM-team-forever/dadamda-backend/assets/75533232/1f218dca-763c-4a20-963d-a27ed4dfe5f5)

- 따라서, chatGPT 및 여러 블로그를 참고하여 해결함
![image](https://github.com/SWM-team-forever/dadamda-backend/assets/75533232/d3dc19c7-d6d8-432a-8fe7-1f12f8bbe8b7)
