### PR TITLE
[DAD-875] 서버 기준 시간 UTC로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ repositories {
 test {
     finalizedBy jacocoTestReport
     useJUnitPlatform()
+
+    //timezone 설정
+    systemProperty "user.timezone", "UTC"
 }
 
 jacoco {

--- a/src/main/java/com/forever/dadamda/DadamdaApplication.java
+++ b/src/main/java/com/forever/dadamda/DadamdaApplication.java
@@ -1,10 +1,18 @@
 package com.forever.dadamda;
 
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class DadamdaApplication {
+
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(DadamdaApplication.class, args);

--- a/src/main/java/com/forever/dadamda/dto/memo/GetMemoResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/memo/GetMemoResponse.java
@@ -1,6 +1,7 @@
 package com.forever.dadamda.dto.memo;
 
 import com.forever.dadamda.entity.Memo;
+import com.forever.dadamda.service.TimeService;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,14 +18,14 @@ public class GetMemoResponse {
     private Long memoId;
     private String memoText;
     private String memoImageUrl;
-    private LocalDateTime createdDate;
+    private Long createdDate;
 
     public static GetMemoResponse of(Memo memo) {
         return GetMemoResponse.builder()
                 .memoId(memo.getId())
                 .memoText(memo.getMemoText())
                 .memoImageUrl(memo.getMemoImageUrl())
-                .createdDate(memo.getCreatedDate())
+                .createdDate(TimeService.fromLocalDateTime(memo.getCreatedDate()))
                 .build();
     }
 }

--- a/src/test/java/com/forever/dadamda/controller/scrap/ScrapControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/scrap/ScrapControllerTest.java
@@ -93,7 +93,7 @@ public class ScrapControllerTest {
                         .param("size", "10")
                         .header("X-AUTH-TOKEN", "aaaaaaa"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].memoList[0].createdDate").value("2023-01-01T11:11:01"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].memoList[0].createdDate").value(1672571461));
     }
 
     @Test

--- a/src/test/java/com/forever/dadamda/service/scrap/ProductServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/scrap/ProductServiceTest.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.service.scrap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.forever.dadamda.dto.scrap.product.GetProductResponse;
+import com.forever.dadamda.service.TimeService;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +44,9 @@ public class ProductServiceTest {
         //given
         //when
         Slice<GetProductResponse> getProductResponse = productService.getProducts(email, PageRequest.of(0, 10));
-        LocalDateTime memoCreatedDate = getProductResponse.getContent().get(0).getMemoList().get(0).getCreatedDate();
+        Long memoCreatedDate = getProductResponse.getContent().get(0).getMemoList().get(0).getCreatedDate();
 
         //then
-        assertEquals( memoCreatedDate, LocalDateTime.of(2023, 1, 1, 11, 11, 1));
+        assertEquals( memoCreatedDate, TimeService.fromLocalDateTime(LocalDateTime.of(2023, 1, 1, 11, 11, 1)));
     }
 }


### PR DESCRIPTION
## 개요
- DAD-875

## 작업사항
- @PostConstruct 애노테이션 이용해서 서버 시준 시간 UTC로 변경 (모든 DATETIME을 UTC로 통일해 서비스 내에서 동일한 DATETIME 기준을 가질 수 있도록 변경)
- 메모 시간 UNIXTIME으로 변경해서 반환
- UNIXTIME 반환 타입 변경에 따른 테스트 코드 변경