### PR TITLE
[DAD-860] feat: 보드 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -2,14 +2,18 @@ package com.forever.dadamda.controller;
 
 import com.forever.dadamda.dto.ApiResponse;
 import com.forever.dadamda.dto.board.CreateBoardRequest;
+import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.service.BoardService;
 import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,5 +53,13 @@ public class BoardController {
         String email = authentication.getName();
         boardService.fixedBoards(email, boardId);
         return ApiResponse.success();
+    }
+
+    @Operation(summary = "보드 목록 조회", description = "여러 개의 보드를 조회합니다")
+    @GetMapping("/v1/boards")
+    public ApiResponse<Slice<GetBoardResponse>> getBoards(Pageable pageable,
+            Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.success(boardService.getBoards(email, pageable));
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
@@ -1,0 +1,36 @@
+package com.forever.dadamda.dto.board;
+
+import com.forever.dadamda.entity.board.Board;
+import com.forever.dadamda.entity.board.TAG;
+import com.forever.dadamda.service.TimeService;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetBoardResponse {
+
+    private Long boardId;
+    private String boardName;
+    private String description;
+    private LocalDateTime isFixed;
+    private TAG tag;
+    private Long modifiedDate;
+
+    public static GetBoardResponse of(Board board) {
+        return GetBoardResponse.builder()
+                .boardId(board.getId())
+                .boardName(board.getName())
+                .description(board.getDescription())
+                .isFixed(board.getFixedDate())
+                .tag(board.getTag())
+                .modifiedDate(TimeService.fromLocalDateTime(board.getModifiedDate()))
+                .build();
+    }
+}

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
@@ -5,7 +5,7 @@ import com.forever.dadamda.entity.user.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
     Optional<Board> findByUserAndName(User user, String name);
 
     Optional<Board> findByUserAndIdAndDeletedDateIsNull(User user, Long boardId);

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
@@ -1,4 +1,4 @@
-package com.forever.dadamda.repository;
+package com.forever.dadamda.repository.board;
 
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    Optional<Board> findFirstByUserAndDeletedDateIsNull(User user);
+    Optional<Board> findByUserAndName(User user, String name);
 
     Optional<Board> findByUserAndIdAndDeletedDateIsNull(User user, Long boardId);
 }

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustom.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.forever.dadamda.repository.board;
+
+import com.forever.dadamda.entity.board.Board;
+import com.forever.dadamda.entity.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface BoardRepositoryCustom {
+
+    Slice<Board> getBoardsList(User user, Pageable pageable);
+}

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustomImpl.java
@@ -1,0 +1,41 @@
+package com.forever.dadamda.repository.board;
+
+import static com.forever.dadamda.entity.board.QBoard.board;
+
+import com.forever.dadamda.entity.board.Board;
+import com.forever.dadamda.entity.user.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+@RequiredArgsConstructor
+public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Board> getBoardsList(User user, Pageable pageable) {
+        List<Board> contents = queryFactory.selectFrom(board)
+                .where(
+                        board.user.eq(user)
+                                .and(board.deletedDate.isNull())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(board.fixedDate.desc().nullsLast(), board.modifiedDate.desc())
+                .fetch();
+
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
+
+    private boolean hasNextPage(List<Board> contents, int pageSize) {
+        if (contents.size() > pageSize) {
+            contents.remove(pageSize);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -4,6 +4,7 @@ import static com.forever.dadamda.service.UUIDService.generateUUID;
 
 import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.board.CreateBoardRequest;
+import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
@@ -11,6 +12,8 @@ import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.service.user.UserService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,5 +54,15 @@ public class BoardService {
         } else {
             board.updateFixedDate(null);
         }
+    }
+
+
+    @Transactional(readOnly = true)
+    public Slice<GetBoardResponse> getBoards(String email, Pageable pageable) {
+        User user = userService.validateUser(email);
+
+        Slice<Board> boardSlice = boardRepository.getBoardsList(user, pageable);
+
+        return boardSlice.map(GetBoardResponse::of);
     }
 }

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -7,7 +7,7 @@ import com.forever.dadamda.dto.board.CreateBoardRequest;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
-import com.forever.dadamda.repository.BoardRepository;
+import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.service.user.UserService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -10,7 +10,7 @@ import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.board.TAG;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.mock.WithCustomMockUser;
-import com.forever.dadamda.repository.BoardRepository;
+import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.repository.UserRepository;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forever.dadamda.dto.board.CreateBoardRequest;
@@ -117,5 +118,37 @@ public class BoardControllerTest {
                         .header("X-AUTH-TOKEN", "aaaaaaa")
                 )
                 .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_it_returns_the_fixed_date_depending_on_whether_the_board_is_fixed_or_not_When_getting_a_list_of_boards()
+            throws Exception {
+        //보드 목록을 조회할 떄, 고정된 날짜가 있는 경우 날짜를 반환하는지 확인
+        mockMvc.perform(get("/v1/boards")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].isFixed").value("2023-01-04T11:11:01"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[2].isFixed").doesNotExist());
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_board_tag_is_returned_to_english_When_getting_a_list_of_boards()
+            throws Exception {
+        //보드 목록을 조회할 떄, tag가 영어로 반환되는지 확인
+        mockMvc.perform(get("/v1/boards")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].tag").value("ENTERTAINMENT_ART"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].tag").value("LIFE_SHOPPING"));
     }
 }

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -6,13 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forever.dadamda.dto.board.CreateBoardRequest;
-import com.forever.dadamda.entity.board.Board;
-import com.forever.dadamda.entity.board.TAG;
-import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.mock.WithCustomMockUser;
 import com.forever.dadamda.repository.board.BoardRepository;
-import com.forever.dadamda.repository.UserRepository;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -28,7 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 @Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
-@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/board-setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public class BoardControllerTest {
 
     @Autowired
@@ -40,15 +35,14 @@ public class BoardControllerTest {
     @Autowired
     private BoardRepository boardRepository;
 
-    @Autowired
-    private UserRepository userRepository;
-
     @Test
     @WithCustomMockUser
     public void should_it_created_normally_When_creating_board_with_the_title_name_and_tag_entered()
             throws Exception {
         //타이틀, 이름, 태그를 입력한 보드를 만들 때, 정상적으로 만들어지는지 확인
         //given
+        boardRepository.deleteAll();
+
         CreateBoardRequest createBoardRequest = CreateBoardRequest.builder()
                 .tag("ENTERTAINMENT_ART")
                 .name("board test1")
@@ -94,11 +88,7 @@ public class BoardControllerTest {
     public void should_it_returns_4xx_error_When_deleting_a_board_that_does_not_exist()
             throws Exception {
         //존재하지 않는 보드를 삭제할 때 4xx에러를 반환하는지 확인
-        //given
-
-        //when
-        //then
-        mockMvc.perform(delete("/v1/boards/2")
+        mockMvc.perform(delete("/v1/boards/100")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-AUTH-TOKEN", "aaaaaaa")
                 )
@@ -110,22 +100,7 @@ public class BoardControllerTest {
     public void should_it_is_deleted_successfully_When_deleting_an_existing_board()
             throws Exception {
         //존재하는 보드를 삭제할 때 성공적으로 삭제되는지 확인
-        //given
-        User user = userRepository.findByEmailAndDeletedDateIsNull("1234@naver.com").get();
-        Board board = Board.builder()
-                .user(user)
-                .uuid(UUID.fromString("3f06af63-a93c-11e4-9797-00505690773f"))
-                .isPublic(true)
-                .tag(TAG.from("ENTERTAINMENT_ART"))
-                .name("test")
-                .build();
-        boardRepository.save(board);
-
-        Long boardId = board.getId();
-
-        //when
-        //then
-        mockMvc.perform(delete("/v1/boards/{boardId}", boardId)
+        mockMvc.perform(delete("/v1/boards/{boardId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-AUTH-TOKEN", "aaaaaaa")
                 )
@@ -137,22 +112,7 @@ public class BoardControllerTest {
     public void should_it_is_fixed_successfully_When_fixing_an_existing_board()
             throws Exception {
         //존재하는 보드를 고정할 때, 성공적으로 고정되는지 확인
-        //given
-        User user = userRepository.findByEmailAndDeletedDateIsNull("1234@naver.com").get();
-        Board board = Board.builder()
-                .user(user)
-                .uuid(UUID.fromString("3f06af63-a93c-11e4-9797-00505690773f"))
-                .isPublic(true)
-                .tag(TAG.from("ENTERTAINMENT_ART"))
-                .name("test")
-                .build();
-        boardRepository.save(board);
-
-        Long boardId = board.getId();
-
-        //when
-        //then
-        mockMvc.perform(patch("/v1/boards/fixed/{boardId}", boardId)
+        mockMvc.perform(patch("/v1/boards/fixed/{boardId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-AUTH-TOKEN", "aaaaaaa")
                 )

--- a/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.forever.dadamda.dto.board.CreateBoardRequest;
+import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.repository.board.BoardRepository;
@@ -12,6 +13,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
@@ -89,5 +92,21 @@ public class BoardServiceTest {
 
         //then
         assertThat(boardRepository.findById(2L).get().getFixedDate()).isNull();
+    }
+
+    @Test
+    void should_boards_are_sorted_by_fixed_date_and_modified_date_order_When_getting_a_list_of_boards() {
+        // 보드 목록을 조회할 때, 고정된 날짜, 수정된 날짜 순으로 정렬되는지 확인
+        //given
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        //when
+        Slice<GetBoardResponse> getBoardResponseSlice = boardService.getBoards(existentEmail, pageRequest);
+
+        //then
+        assertThat(getBoardResponseSlice.getContent().get(0).getBoardId()).isEqualTo(4L);
+        assertThat(getBoardResponseSlice.getContent().get(1).getBoardId()).isEqualTo(2L);
+        assertThat(getBoardResponseSlice.getContent().get(2).getBoardId()).isEqualTo(3L);
+        assertThat(getBoardResponseSlice.getContent().get(3).getBoardId()).isEqualTo(1L);
     }
 }

--- a/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
@@ -6,7 +6,7 @@ import com.forever.dadamda.dto.board.CreateBoardRequest;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.board.TAG;
 import com.forever.dadamda.entity.user.User;
-import com.forever.dadamda.repository.BoardRepository;
+import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
@@ -4,13 +4,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.forever.dadamda.dto.board.CreateBoardRequest;
 import com.forever.dadamda.entity.board.Board;
-import com.forever.dadamda.entity.board.TAG;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,7 +19,7 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 @SpringBootTest
 @ActiveProfiles("test")
 @Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
-@Sql(scripts = "/setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "/board-setup.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 public class BoardServiceTest {
 
     @Autowired
@@ -36,12 +34,14 @@ public class BoardServiceTest {
     String existentEmail = "1234@naver.com";
 
     @Test
-    void should_the_name_description_and_heart_count_are_generated_normally_When_creating_the_board() {
+    void should_the_description_and_heart_count_are_generated_normally_When_creating_the_board() {
         // 새로운 보드가 정상적으로 이름, 설명, 하트수가 생성되는지 확인
         //given
+        boardRepository.deleteAll();
+
         CreateBoardRequest createBoardRequest = CreateBoardRequest.builder()
                 .tag("ENTERTAINMENT_ART")
-                .name("board test1")
+                .name("board normally test1")
                 .description("board test2")
                 .build();
 
@@ -51,9 +51,8 @@ public class BoardServiceTest {
         boardService.createBoards(existentEmail, createBoardRequest);
 
         //then
-        Optional<Board> board = boardRepository.findFirstByUserAndDeletedDateIsNull(user);
+        Optional<Board> board = boardRepository.findByUserAndName(user, "board normally test1");
         assertThat(board).isNotNull();
-        assertThat(board.get().getName()).isEqualTo("board test1");
         assertThat(board.get().getDescription()).isEqualTo("board test2");
         assertThat(board.get().getHeartCnt()).isEqualTo(0L);
     }
@@ -62,48 +61,22 @@ public class BoardServiceTest {
     void should_the_deleted_date_is_not_null_When_deleting_a_board() {
         // 보드를 삭제했을 때, 삭제된 날짜가 null이 아닌지 확인
         //given
-        User user = userRepository.findByEmailAndDeletedDateIsNull(existentEmail).get();
-
-        Board board = Board.builder()
-                .user(user)
-                .uuid(UUID.fromString("3f06af63-a93c-11e4-9797-00505690773f"))
-                .isPublic(true)
-                .tag(TAG.from("ENTERTAINMENT_ART"))
-                .name("test")
-                .build();
-        boardRepository.save(board);
-
-        Long boardId = board.getId();
-
         //when
-        boardService.deleteBoards(existentEmail, boardId);
+        boardService.deleteBoards(existentEmail, 1L);
 
         //then
-        assertThat(boardRepository.findById(boardId).get().getDeletedDate()).isNotNull();
+        assertThat(boardRepository.findById(1L).get().getDeletedDate()).isNotNull();
     }
 
     @Test
     void should_the_fixed_date_is_before_or_equal_to_now_When_fixing_a_board() {
         // 보드를 고정했을 때, 고정된 날짜가 null이 아닌지(보드가 정상적으로 고정되는지) 확인
         //given
-        User user = userRepository.findByEmailAndDeletedDateIsNull(existentEmail).get();
-
-        Board board = Board.builder()
-                .user(user)
-                .uuid(UUID.fromString("3f06af63-a93c-11e4-9797-00505690773f"))
-                .isPublic(true)
-                .tag(TAG.from("ENTERTAINMENT_ART"))
-                .name("test")
-                .build();
-        boardRepository.save(board);
-
-        Long boardId = board.getId();
-
         //when
-        boardService.fixedBoards(existentEmail, boardId);
+        boardService.fixedBoards(existentEmail, 1L);
 
         //then
-        assertThat(boardRepository.findById(boardId).get().getFixedDate()).isBeforeOrEqualTo(
+        assertThat(boardRepository.findById(1L).get().getFixedDate()).isBeforeOrEqualTo(
                 LocalDateTime.now());
     }
 
@@ -111,24 +84,10 @@ public class BoardServiceTest {
     void should_the_fixed_date_is_null_When_fixing_a_fixed_board() {
         // 고정된 보드를 다시 고정할 때, 고정된 날짜가 null이 되는지(고정이 취소되는지) 확인
         //given
-        User user = userRepository.findByEmailAndDeletedDateIsNull(existentEmail).get();
-
-        Board board = Board.builder()
-                .user(user)
-                .uuid(UUID.fromString("3f06af63-a93c-11e4-9797-00505690773f"))
-                .isPublic(true)
-                .tag(TAG.from("ENTERTAINMENT_ART"))
-                .name("test")
-                .fixedDate(LocalDateTime.of(2021, 1, 1, 0, 0, 0))
-                .build();
-        boardRepository.save(board);
-
-        Long boardId = board.getId();
-
         //when
-        boardService.fixedBoards(existentEmail, boardId);
+        boardService.fixedBoards(existentEmail, 2L);
 
         //then
-        assertThat(boardRepository.findById(boardId).get().getFixedDate()).isNull();
+        assertThat(boardRepository.findById(2L).get().getFixedDate()).isNull();
     }
 }

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -1,0 +1,10 @@
+-- User 데이터 삽입
+INSERT INTO users (user_id, name, provider, role, email, profile_url)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
+
+-- Board 데이터 삽입
+INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date)
+VALUES (1, 1, 'board1', 'test', '0782ef48-a439-11', 0 ,'2023-01-01 11:11:01', 1, '2023-01-01 11:11:01');
+
+INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
+VALUES (1, 2, 'board1', 'test', '0782ef48-a439-12', 0 ,'2023-01-01 11:11:01', 1, '2023-01-01 11:11:01', '2023-01-01 11:11:01');

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -7,4 +7,10 @@ INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date
 VALUES (1, 1, 'board1', 'test', '0782ef48-a439-11', 0 ,'2023-01-01 11:11:01', 1, '2023-01-01 11:11:01');
 
 INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
-VALUES (1, 2, 'board1', 'test', '0782ef48-a439-12', 0 ,'2023-01-01 11:11:01', 1, '2023-01-01 11:11:01', '2023-01-01 11:11:01');
+VALUES (1, 2, 'board2', 'test', '0782ef48-a439-12', 1 ,'2023-01-01 11:11:01', 1, '2023-01-02 11:11:01', '2023-01-03 11:11:01');
+
+INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date)
+VALUES (1, 3, 'board3', 'test', '0782ef48-a439-13', 0 ,'2023-01-01 11:11:01', 1, '2023-01-03 11:11:01');
+
+INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
+VALUES (1, 4, 'board4', 'test', '0782ef48-a439-14', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01');


### PR DESCRIPTION
## 개요
- DAD-860

## 작업사항
- 보드 목록 조회 기능 구현 + 테스트 코드 작성
- board 관련 테스트 코드에서 board를 저장하는 부분을 board-setup.sql로 변경