### PR TITLE
[DAD-910] refactor: 사용하지 않는 REDIRECT_URI_PARAM_COOKIE_NAME 제거 및 sentry 추가

### DIFF
--- a/src/main/java/com/forever/dadamda/config/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/forever/dadamda/config/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,7 +1,6 @@
 package com.forever.dadamda.config.oauth;
 
 import com.forever.dadamda.config.oauth.util.CookieUtils;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
@@ -12,7 +11,6 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
     public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
-    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
     private static final int cookieExpireSeconds = 180;
 
     @Override
@@ -26,15 +24,10 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
         if (authorizationRequest == null) {
             CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
             return;
         }
 
         CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
-        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
-        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
-            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
-        }
     }
 
     @Override
@@ -44,6 +37,5 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
     public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
         CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
     }
 }

--- a/src/main/java/com/forever/dadamda/config/oauth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/forever/dadamda/config/oauth/handler/OAuth2FailureHandler.java
@@ -1,17 +1,15 @@
 package com.forever.dadamda.config.oauth.handler;
 
-import static com.forever.dadamda.config.oauth.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forever.dadamda.config.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
-import com.forever.dadamda.config.oauth.util.CookieUtils;
+import com.forever.dadamda.dto.ErrorCode;
+import com.forever.dadamda.dto.JwtErrorResponse;
+import io.sentry.Sentry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -24,17 +22,21 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
     @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-                .map(Cookie::getValue)
-                .orElse(("/"));
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
 
-        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("error", exception.getLocalizedMessage())
-                .build().toUriString();
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setCharacterEncoding("utf-8");
+        response.setContentType("application/json");
+
+        JwtErrorResponse jwtErrorResponse = new JwtErrorResponse(
+                ErrorCode.INVALID_AUTH_TOKEN.getCode(), ErrorCode.INVALID_AUTH_TOKEN.getMessage());
+        ObjectMapper objectMapper = new ObjectMapper();
+        String result = objectMapper.writeValueAsString(jwtErrorResponse);
+
+        Sentry.captureException(exception);
+
+        response.getWriter().write(result);
 
         httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
-
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/ErrorCode.java
+++ b/src/main/java/com/forever/dadamda/dto/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
      */
     INVALID("BR000", "잘못된 요청입니다."),
 
-    INVALID_AUTH_TOKEN("BR001", "만료된 엑세스 토큰입니다."),
+    INVALID_AUTH_TOKEN("BR001", "만료되거나 잘못된 엑세스 토큰입니다."),
     INVALID_DUPLICATED_SCRAP("BR002","이미 저장된 URL입니다."),
 
     /**

--- a/src/main/java/com/forever/dadamda/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/forever/dadamda/exception/JwtAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.exception;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.JwtErrorResponse;
+import io.sentry.Sentry;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -25,6 +26,8 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
                 ErrorCode.INVALID_AUTH_TOKEN.getCode(), ErrorCode.INVALID_AUTH_TOKEN.getMessage());
         ObjectMapper objectMapper = new ObjectMapper();
         String result = objectMapper.writeValueAsString(jwtErrorResponse);
+
+        Sentry.captureException(authException);
 
         response.getWriter().write(result);
     }


### PR DESCRIPTION
## 개요
- DAD-910

## 작업사항
- 사용하지 않는 REDIRECT_URI_PARAM_COOKIE_NAME 제거
- sentry 추가