### PR TITLE
[DAD-930] feat: 보드 목록 검색 API 구현

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -9,6 +9,7 @@ import com.forever.dadamda.dto.board.GetBoardDetailResponse;
 import com.forever.dadamda.service.BoardService;
 import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -74,7 +76,7 @@ public class BoardController {
         return ApiResponse.success(GetBoardCountResponse.of(boardService.getBoardCount(email)));
     }
 
-    @Operation(summary = "보드 내용 조회", description = "전체 보드 개수 정보를 조회할 수 있습니다.")
+    @Operation(summary = "보드 내용 조회", description = "보드 정보를 조회할 수 있습니다.")
     @GetMapping("/v1/boards/{boardId}")
     public ApiResponse<GetBoardDetailResponse> getBoards(
             @PathVariable @Positive @NotNull Long boardId, Authentication authentication) {
@@ -90,5 +92,17 @@ public class BoardController {
         String email = authentication.getName();
         boardService.updateBoards(email, boardId, updateBoardRequest);
         return ApiResponse.success();
+    }
+
+    @Operation(summary = "보드 검색", description = "보드를 보드명으로 검색할 수 있습니다.")
+    @GetMapping("/v1/boards/search")
+    public ApiResponse<Slice<GetBoardResponse>> searchBoards(
+            @RequestParam("keyword") @NotBlank String keyword,
+            Pageable pageable,
+            Authentication authentication) {
+
+        String email = authentication.getName();
+
+        return ApiResponse.success(boardService.searchBoards(email, keyword, pageable));
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
@@ -17,7 +17,7 @@ public class CreateBoardRequest {
 
     @NotBlank(message = "보드명을 입력해주세요.")
     @Size(max = 100, message = "최대 100자까지 입력할 수 있습니다.")
-    private String name;
+    private String title;
 
     @Size(max = 1000, message = "최대 1000자까지 입력할 수 있습니다.")
     private String description;
@@ -28,7 +28,7 @@ public class CreateBoardRequest {
     public Board toEntity(User user, UUID uuid, boolean isPublic) {
         return Board.builder()
                 .user(user)
-                .name(name)
+                .title(title)
                 .description(description)
                 .tag(TAG.from(tag))
                 .uuid(uuid)

--- a/src/main/java/com/forever/dadamda/dto/board/GetBoardDetailResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/board/GetBoardDetailResponse.java
@@ -10,14 +10,14 @@ import lombok.Getter;
 public class GetBoardDetailResponse {
 
     private Long boardId;
-    private String name;
+    private String title;
     private String description;
     private TAG tag;
 
     public static GetBoardDetailResponse of(Board board) {
         return GetBoardDetailResponse.builder()
                 .boardId(board.getId())
-                .name(board.getName())
+                .title(board.getTitle())
                 .description(board.getDescription())
                 .tag(board.getTag())
                 .build();

--- a/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
@@ -4,6 +4,7 @@ import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.board.TAG;
 import com.forever.dadamda.service.TimeService;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,18 +18,18 @@ import lombok.NoArgsConstructor;
 public class GetBoardResponse {
 
     private Long boardId;
-    private String boardName;
-    private String description;
+    private String name;
     private LocalDateTime isFixed;
+    private UUID uuid;
     private TAG tag;
     private Long modifiedDate;
 
     public static GetBoardResponse of(Board board) {
         return GetBoardResponse.builder()
                 .boardId(board.getId())
-                .boardName(board.getName())
-                .description(board.getDescription())
+                .name(board.getName())
                 .isFixed(board.getFixedDate())
+                .uuid(board.getUuid())
                 .tag(board.getTag())
                 .modifiedDate(TimeService.fromLocalDateTime(board.getModifiedDate()))
                 .build();

--- a/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 public class GetBoardResponse {
 
     private Long boardId;
-    private String name;
+    private String title;
     private LocalDateTime isFixed;
     private UUID uuid;
     private TAG tag;
@@ -27,7 +27,7 @@ public class GetBoardResponse {
     public static GetBoardResponse of(Board board) {
         return GetBoardResponse.builder()
                 .boardId(board.getId())
-                .name(board.getName())
+                .title(board.getTitle())
                 .isFixed(board.getFixedDate())
                 .uuid(board.getUuid())
                 .tag(board.getTag())

--- a/src/main/java/com/forever/dadamda/dto/board/UpdateBoardRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/board/UpdateBoardRequest.java
@@ -11,7 +11,7 @@ public class UpdateBoardRequest {
 
     @NotBlank(message = "보드명을 입력해주세요.")
     @Size(max = 100, message = "최대 100자까지 입력할 수 있습니다.")
-    private String name;
+    private String title;
 
     @Size(max = 1000, message = "최대 1000자까지 입력할 수 있습니다.")
     private String description;

--- a/src/main/java/com/forever/dadamda/entity/board/Board.java
+++ b/src/main/java/com/forever/dadamda/entity/board/Board.java
@@ -37,7 +37,7 @@ public class Board extends BaseTimeEntity {
     private User user;
 
     @Column(length = 100, nullable = false)
-    private String name;
+    private String title;
 
     @Column(columnDefinition = "boolean", nullable = false)
     private boolean isPublic;
@@ -60,10 +60,10 @@ public class Board extends BaseTimeEntity {
     private Long shareCnt;
 
     @Builder
-    Board(User user, String name, TAG tag, UUID uuid, String description, boolean isPublic,
+    Board(User user, String title, TAG tag, UUID uuid, String description, boolean isPublic,
             LocalDateTime fixedDate) {
         this.user = user;
-        this.name = name;
+        this.title = title;
         this.tag = tag;
         this.uuid = uuid;
         this.description = description;
@@ -76,7 +76,7 @@ public class Board extends BaseTimeEntity {
     }
 
     public void updateBoard(UpdateBoardRequest request) {
-        this.name = request.getName();
+        this.title = request.getTitle();
         this.tag = TAG.from(request.getTag());
         this.description = request.getDescription();
     }

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
-    Optional<Board> findByUserAndName(User user, String name);
+    Optional<Board> findByUserAndTitle(User user, String title);
 
     Optional<Board> findByUserAndIdAndDeletedDateIsNull(User user, Long boardId);
 

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustom.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustom.java
@@ -8,4 +8,6 @@ import org.springframework.data.domain.Slice;
 public interface BoardRepositoryCustom {
 
     Slice<Board> getBoardsList(User user, Pageable pageable);
+
+    Slice<Board> searchKeywordInBoardList(User user, String keyword, Pageable pageable);
 }

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustomImpl.java
@@ -31,6 +31,22 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
         return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
     }
 
+    @Override
+    public Slice<Board> searchKeywordInBoardList(User user, String keyword, Pageable pageable) {
+        List<Board> contents = queryFactory.selectFrom(board)
+                .where(
+                        board.user.eq(user)
+                                .and(board.deletedDate.isNull())
+                                .and(board.name.containsIgnoreCase(keyword))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(board.fixedDate.desc().nullsLast(), board.modifiedDate.desc())
+                .fetch();
+
+        return new SliceImpl<>(contents, pageable, hasNextPage(contents, pageable.getPageSize()));
+    }
+
     private boolean hasNextPage(List<Board> contents, int pageSize) {
         if (contents.size() > pageSize) {
             contents.remove(pageSize);

--- a/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/forever/dadamda/repository/board/BoardRepositoryCustomImpl.java
@@ -37,7 +37,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
                 .where(
                         board.user.eq(user)
                                 .and(board.deletedDate.isNull())
-                                .and(board.name.containsIgnoreCase(keyword))
+                                .and(board.title.containsIgnoreCase(keyword))
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -4,9 +4,9 @@ import static com.forever.dadamda.service.UUIDService.generateUUID;
 
 import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.board.CreateBoardRequest;
+import com.forever.dadamda.dto.board.GetBoardDetailResponse;
 import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
-import com.forever.dadamda.dto.board.GetBoardDetailResponse;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
@@ -91,5 +91,14 @@ public class BoardService {
         return boardRepository.findByUserAndIdAndDeletedDateIsNull(user, boardId)
                 .map(GetBoardDetailResponse::of)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<GetBoardResponse> searchBoards(String email, String keyword, Pageable pageable) {
+        User user = userService.validateUser(email);
+
+        Slice<Board> boardSlice = boardRepository.searchKeywordInBoardList(user, keyword, pageable);
+
+        return boardSlice.map(GetBoardResponse::of);
     }
 }

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -57,7 +57,7 @@ public class BoardControllerTest {
 
         CreateBoardRequest createBoardRequest = CreateBoardRequest.builder()
                 .tag("ENTERTAINMENT_ART")
-                .name("board test1")
+                .title("board test1")
                 .description("board test2")
                 .build();
         String content = objectMapper.writeValueAsString(createBoardRequest);
@@ -80,7 +80,7 @@ public class BoardControllerTest {
         //given
         CreateBoardRequest createBoardRequest = CreateBoardRequest.builder()
                 .tag("ENTERTAINMENT_ARTIST")
-                .name("test")
+                .title("test")
                 .description("test")
                 .build();
         String content = objectMapper.writeValueAsString(createBoardRequest);
@@ -171,7 +171,7 @@ public class BoardControllerTest {
         //given
         UpdateBoardRequest updateBoardRequest = UpdateBoardRequest.builder()
                 .tag("LIFE_SHOPPING")
-                .name("test")
+                .title("test")
                 .description("test123")
                 .build();
         String content = objectMapper.writeValueAsString(updateBoardRequest);
@@ -210,7 +210,7 @@ public class BoardControllerTest {
                 )
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.boardId").value(1L))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.name").value("board1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").value("board1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.description").value("test"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.tag").value("ENTERTAINMENT_ART"));
     }
@@ -227,7 +227,7 @@ public class BoardControllerTest {
         User user = userRepository.findById(1L).get();
         Board board = Board.builder()
                 .isPublic(true)
-                .name("board10")
+                .title("board10")
                 .description("test")
                 .tag(LIFE_SHOPPING)
                 .fixedDate(LocalDateTime.of(2023, 1, 30, 11, 11, 1))
@@ -246,7 +246,7 @@ public class BoardControllerTest {
                         .param("size", "10")
                 )
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].name").value("board10"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("board10"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].description").doesNotExist())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].isFixed").value("2023-01-30T11:11:01"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].uuid").value(boardUUID.toString()))

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -1,5 +1,7 @@
 package com.forever.dadamda.controller;
 
+import static com.forever.dadamda.entity.board.TAG.LIFE_SHOPPING;
+import static com.forever.dadamda.service.UUIDService.generateUUID;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -8,8 +10,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forever.dadamda.dto.board.CreateBoardRequest;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
+import com.forever.dadamda.entity.board.Board;
+import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.mock.WithCustomMockUser;
+import com.forever.dadamda.repository.UserRepository;
 import com.forever.dadamda.repository.board.BoardRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -36,6 +43,9 @@ public class BoardControllerTest {
 
     @Autowired
     private BoardRepository boardRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
     @WithCustomMockUser
@@ -203,5 +213,43 @@ public class BoardControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.name").value("board1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.description").value("test"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.tag").value("ENTERTAINMENT_ART"));
+    }
+
+    @Test
+    @WithCustomMockUser
+    public void should_the_name_fixed_date_uuid_and_tag_are_returned_successfully_When_searching_for_a_board()
+            throws Exception {
+        // 보드를 검색할 때, 이름, 고정된 날짜, uuid, 태그가 성공적으로 출력된다.
+        // given
+        boardRepository.deleteAll();
+
+        UUID boardUUID = generateUUID();
+        User user = userRepository.findById(1L).get();
+        Board board = Board.builder()
+                .isPublic(true)
+                .name("board10")
+                .description("test")
+                .tag(LIFE_SHOPPING)
+                .fixedDate(LocalDateTime.of(2023, 1, 30, 11, 11, 1))
+                .uuid(boardUUID)
+                .user(user)
+                .build();
+        boardRepository.save(board);
+
+        //when
+        //then
+        mockMvc.perform(get("/v1/boards/search")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                        .param("keyword", "board10")
+                        .param("page", "0")
+                        .param("size", "10")
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].name").value("board10"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].description").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].isFixed").value("2023-01-30T11:11:01"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].uuid").value(boardUUID.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].tag").value("LIFE_SHOPPING"));
     }
 }

--- a/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
@@ -105,7 +105,8 @@ public class BoardServiceTest {
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         //when
-        Slice<GetBoardResponse> getBoardResponseSlice = boardService.getBoardList(existentEmail, pageRequest);
+        Slice<GetBoardResponse> getBoardResponseSlice = boardService.getBoardList(existentEmail,
+                pageRequest);
 
         //then
         assertThat(getBoardResponseSlice.getContent().get(0).getBoardId()).isEqualTo(4L);
@@ -159,7 +160,7 @@ public class BoardServiceTest {
                 LocalDateTime.of(2023, 1, 1, 11, 11, 1));
 
     }
-  
+
     @Test
     void should_the_number_of_boards_is_returned_successfully_except_for_deleted_ones_When_getting_the_number_of_boards() {
         // 보드 개수 조회할 때, 삭제된 보드는 제외하고 개수가 정상적으로 나오는지 확인
@@ -181,5 +182,36 @@ public class BoardServiceTest {
         //then
         assertThatThrownBy(() -> boardService.getBoard(existentEmail, deletedBoardId))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void should_deleted_boards_are_not_searched_When_searching_for_a_board() {
+        // 보드를 검색할 때, 삭제된 보드는 검색 안 된다.
+        //given
+        String keyword = "board5";
+
+        //when
+        Slice<GetBoardResponse> getBoardResponseSlice = boardService.searchBoards(existentEmail,
+                keyword, PageRequest.of(0, 10));
+
+        //then
+        assertThat(getBoardResponseSlice.getNumberOfElements()).isEqualTo(0);
+    }
+
+    @Test
+    void should_boards_are_sorted_by_fixed_date_and_modified_date_order_When_searching_for_a_board() {
+        // 보드를 검색할 때, 고정된 날짜, 수정된 날짜 순으로 정렬되는지 확인
+        //given
+        String keyword = "board";
+
+        //when
+        Slice<GetBoardResponse> getBoardResponseSlice = boardService.searchBoards(existentEmail,
+                keyword, PageRequest.of(0, 10));
+
+        //then
+        assertThat(getBoardResponseSlice.getContent().get(0).getBoardId()).isEqualTo(4L);
+        assertThat(getBoardResponseSlice.getContent().get(1).getBoardId()).isEqualTo(2L);
+        assertThat(getBoardResponseSlice.getContent().get(2).getBoardId()).isEqualTo(3L);
+        assertThat(getBoardResponseSlice.getContent().get(3).getBoardId()).isEqualTo(1L);
     }
 }

--- a/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
@@ -48,7 +48,7 @@ public class BoardServiceTest {
 
         CreateBoardRequest createBoardRequest = CreateBoardRequest.builder()
                 .tag("ENTERTAINMENT_ART")
-                .name("board normally test1")
+                .title("board normally test1")
                 .description("board test2")
                 .build();
 
@@ -58,7 +58,7 @@ public class BoardServiceTest {
         boardService.createBoards(existentEmail, createBoardRequest);
 
         //then
-        Optional<Board> board = boardRepository.findByUserAndName(user, "board normally test1");
+        Optional<Board> board = boardRepository.findByUserAndTitle(user, "board normally test1");
         assertThat(board).isNotNull();
         assertThat(board.get().getDescription()).isEqualTo("board test2");
         assertThat(board.get().getHeartCnt()).isEqualTo(0L);
@@ -122,7 +122,7 @@ public class BoardServiceTest {
         Long boardId = 1L;
         UpdateBoardRequest updateBoardRequest = UpdateBoardRequest.builder()
                 .tag("LIFE_SHOPPING")
-                .name("test")
+                .title("test")
                 .description("test123")
                 .build();
 
@@ -135,7 +135,7 @@ public class BoardServiceTest {
         assertThat(board.getModifiedDate()).isAfter(
                 LocalDateTime.of(2023, 1, 2, 11, 11, 1));
         assertThat(board.getTag()).isEqualTo(LIFE_SHOPPING);
-        assertThat(board.getName()).isEqualTo("test");
+        assertThat(board.getTitle()).isEqualTo("test");
         assertThat(board.getDescription()).isEqualTo("test123");
     }
 
@@ -146,7 +146,7 @@ public class BoardServiceTest {
         Long boardId = 1L;
         UpdateBoardRequest updateBoardRequest = UpdateBoardRequest.builder()
                 .tag("ENTERTAINMENT_ART")
-                .name("board1")
+                .title("board1")
                 .description("test")
                 .build();
 

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -3,17 +3,17 @@ INSERT INTO users (user_id, name, provider, role, email, profile_url)
 VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
 
 -- Board 데이터 삽입
-INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date)
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date)
 VALUES (1, 1, 'board1', 'test', '0782ef48-a439-11', 0 ,'2023-01-01 11:11:01', 1, '2023-01-01 11:11:01');
 
-INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
 VALUES (1, 2, 'board2', 'test', '0782ef48-a439-12', 1 ,'2023-01-01 11:11:01', 1, '2023-01-02 11:11:01', '2023-01-03 11:11:01');
 
-INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date)
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date)
 VALUES (1, 3, 'board3', 'test', '0782ef48-a439-13', 0 ,'2023-01-01 11:11:01', 1, '2023-01-03 11:11:01');
 
-INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
 VALUES (1, 4, 'board4', 'test', '0782ef48-a439-14', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01');
 
-INSERT INTO board (user_id, board_id, name, description, uuid, tag, created_date, is_public, modified_date, deleted_date)
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, deleted_date)
 VALUES (1, 5, 'board5', 'test', '0782ef48-a439-15', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01');


### PR DESCRIPTION
## 개요
- DAD-930

## 작업사항
- 보드 목록 검색 API 구현 + 테스트 코드 작성
- 보드 목록 조회 응답값에 설명 제거 및 UUID 추가
- 보드명 관련 명칭을 name에서 title로 변경