### PR TITLE
[DAD-1016] 보드 썸네일 이미지 업로드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,9 @@ dependencies {
     // QueryDSL
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-aws-core:2.2.6.RELEASE'
 }
 
 // querydsl

--- a/src/main/java/com/forever/dadamda/config/S3Config.java
+++ b/src/main/java/com/forever/dadamda/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.forever.dadamda.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    protected AmazonS3 generateS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -8,14 +8,17 @@ import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.dto.board.UpdateBoardContentsRequest;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
 import com.forever.dadamda.dto.board.GetBoardDetailResponse;
+import com.forever.dadamda.dto.board.UploadBoardThumbnailRequest;
 import com.forever.dadamda.service.BoardService;
 import io.swagger.v3.oas.annotations.Operation;
+import java.io.IOException;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.Authentication;
@@ -33,6 +36,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Validated
 @RequiredArgsConstructor
 @RestController
+@Slf4j
 public class BoardController {
 
     private final BoardService boardService;
@@ -149,5 +153,11 @@ public class BoardController {
         String email = authentication.getName();
 
         return ApiResponse.success(boardService.uploadFile(email, boardUUID, file));
+    }
+
+    @PostMapping("/thumbnail/test")
+    public ApiResponse<String> uploadFileTest(@RequestParam("file") MultipartFile file) throws IOException {
+        log.info("file: {}", file.getBytes());
+        return ApiResponse.success(boardService.uploadFileTest(file));
     }
 }

--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -15,7 +15,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,6 +28,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Validated
 @RequiredArgsConstructor
@@ -140,5 +140,14 @@ public class BoardController {
         String email = authentication.getName();
 
         return ApiResponse.success(boardService.getBoardContents(email, UUID.fromString(boardUUID)));
+    }
+
+    @Operation(summary = "보드 썸네일 업로드", description = "보드의 썸네일을 업로드합니다.")
+    @PostMapping("/v1/boards/{boardUUID}/thumbnail")
+    public ApiResponse<String> uploadFile(@RequestParam("file") MultipartFile file, Authentication authentication, @PathVariable @NotNull @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", message = "UUID가 올바르지 않습니다.") String boardUUID) {
+
+        String email = authentication.getName();
+
+        return ApiResponse.success(boardService.uploadFile(email, boardUUID, file));
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
@@ -9,10 +9,12 @@ import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 @Builder
+@NoArgsConstructor
 public class CreateBoardRequest {
 
     @NotBlank(message = "보드명을 입력해주세요.")

--- a/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/board/GetBoardResponse.java
@@ -23,6 +23,7 @@ public class GetBoardResponse {
     private UUID uuid;
     private TAG tag;
     private Long modifiedDate;
+    private String thumbnailUrl;
 
     public static GetBoardResponse of(Board board) {
         return GetBoardResponse.builder()
@@ -32,6 +33,7 @@ public class GetBoardResponse {
                 .uuid(board.getUuid())
                 .tag(board.getTag())
                 .modifiedDate(TimeService.fromLocalDateTime(board.getModifiedDate()))
+                .thumbnailUrl(board.getThumbnailUrl())
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/entity/board/Board.java
+++ b/src/main/java/com/forever/dadamda/entity/board/Board.java
@@ -63,6 +63,9 @@ public class Board extends BaseTimeEntity {
     @ColumnDefault("0")
     private Long shareCnt;
 
+    @Column(length = 2084)
+    private String thumbnailUrl;
+
     @Builder
     Board(User user, String title, TAG tag, UUID uuid, String description, boolean isPublic,
             LocalDateTime fixedDate) {
@@ -87,5 +90,9 @@ public class Board extends BaseTimeEntity {
 
     public void updateContents(UpdateBoardContentsRequest request) {
         this.contents = request.getContents();
+    }
+
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
     }
 }

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.service;
 import static com.forever.dadamda.service.UUIDService.generateUUID;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
@@ -14,11 +15,13 @@ import com.forever.dadamda.dto.board.GetBoardDetailResponse;
 import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.dto.board.UpdateBoardContentsRequest;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
+import com.forever.dadamda.dto.board.UploadBoardThumbnailRequest;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.service.user.UserService;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -168,5 +171,14 @@ public class BoardService {
             throw new IllegalArgumentException("파일 변환에 실패했습니다.");
         }
         return convertedFile;
+    }
+
+    @Transactional
+    public String uploadFileTest(MultipartFile file) throws IOException {
+        String fileName = "test.png";
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        s3Client.putObject(bucketName, fileName, file.getInputStream(), objectMetadata);
+        return fileName;
     }
 }

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -2,6 +2,11 @@ package com.forever.dadamda.service;
 
 import static com.forever.dadamda.service.UUIDService.generateUUID;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.util.IOUtils;
 import com.forever.dadamda.dto.ErrorCode;
 import com.forever.dadamda.dto.board.CreateBoardRequest;
 import com.forever.dadamda.dto.board.GetBoardContentsResponse;
@@ -14,13 +19,19 @@ import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.service.user.UserService;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +39,12 @@ public class BoardService {
 
     private final UserService userService;
     private final BoardRepository boardRepository;
+
+    @Value("${application.bucket.name}")
+    private String bucketName;
+
+    @Autowired
+    private AmazonS3 s3Client;
 
     @Transactional
     public void createBoards(String email, CreateBoardRequest createBoardRequest) {
@@ -123,5 +140,33 @@ public class BoardService {
         return boardRepository.findByUserAndUuidAndDeletedDateIsNull(user, boardUUID)
                 .map(GetBoardContentsResponse::of)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
+    }
+
+    @Transactional
+    public String uploadFile(String email, String boardUUID, MultipartFile file) {
+        User user = userService.validateUser(email);
+
+        Board board = boardRepository.findByUserAndUuidAndDeletedDateIsNull(user, UUID.fromString(boardUUID))
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
+
+        File fileObj = convertMultiPartFileToFile(file);
+        String fileName = boardUUID + file.getOriginalFilename();
+        s3Client.putObject(new PutObjectRequest(bucketName, fileName, fileObj));
+        fileObj.delete();
+
+        String url = s3Client.getUrl(bucketName, fileName).toString();
+        board.updateThumbnailUrl(url);
+
+        return boardUUID;
+    }
+
+    private File convertMultiPartFileToFile(MultipartFile file) {
+        File convertedFile = new File(file.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("파일 변환에 실패했습니다.");
+        }
+        return convertedFile;
     }
 }


### PR DESCRIPTION
## 개요
- DAD-1016

## 작업사항
- Board 엔티티에 thumbnailUrl 속성값 추가 (length = 2084)
- 보드 썸네일 이미지 업로드 API 구현 (업로드와 동시에 해당 보드 데이터 thumbnailUrl 값 업데이트)
- GetBoardResponse에 thumbnailUrl 포함되도록 수정