### PR TITLE
[DAD-1038] feat: 공유된 보드 컨텐츠 조회, 타이틀 조회 API 분리

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -7,6 +7,7 @@ import com.forever.dadamda.dto.board.GetBoardCountResponse;
 import com.forever.dadamda.dto.board.GetBoardIsSharedResponse;
 import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.dto.board.GetSharedBoardContentsResponse;
+import com.forever.dadamda.dto.board.GetSharedBoardTitleResponse;
 import com.forever.dadamda.dto.board.UpdateBoardContentsRequest;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
 import com.forever.dadamda.dto.board.GetBoardDetailResponse;
@@ -176,5 +177,14 @@ public class BoardController {
                     message = "UUID가 올바르지 않습니다.") String boardUUID) {
 
         return ApiResponse.success(boardService.getSharedBoardContents(UUID.fromString(boardUUID)));
+    }
+
+    @Operation(summary = "공유된 보드 타이틀 조회", description = "공유된 보드 타이틀을 조회합니다.")
+    @GetMapping("/ov1/share/boards/title/{boardUUID}")
+    public ApiResponse<GetSharedBoardTitleResponse> getSharedBoardTitle(
+            @PathVariable @NotNull @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                    message = "UUID가 올바르지 않습니다.") String boardUUID) {
+
+        return ApiResponse.success(boardService.getSharedBoardTitle(UUID.fromString(boardUUID)));
     }
 }

--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -170,7 +170,7 @@ public class BoardController {
     }
 
     @Operation(summary = "공유된 보드 컨텐츠 조회", description = "공유된 보드 컨텐츠를 조회합니다.")
-    @GetMapping("/ov1/share/boards/{boardUUID}")
+    @GetMapping("/ov1/share/boards/contents/{boardUUID}")
     public ApiResponse<GetSharedBoardContentsResponse> getSharedBoardContents(
             @PathVariable @NotNull @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
                     message = "UUID가 올바르지 않습니다.") String boardUUID) {

--- a/src/main/java/com/forever/dadamda/dto/board/GetSharedBoardContentsResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/board/GetSharedBoardContentsResponse.java
@@ -9,12 +9,10 @@ import lombok.Getter;
 public class GetSharedBoardContentsResponse {
 
     private String contents;
-    private String title;
 
     public static GetSharedBoardContentsResponse of(Board board) {
         return GetSharedBoardContentsResponse.builder()
                 .contents(board.getContents())
-                .title(board.getTitle())
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/board/GetSharedBoardTitleResponse.java
+++ b/src/main/java/com/forever/dadamda/dto/board/GetSharedBoardTitleResponse.java
@@ -1,0 +1,17 @@
+package com.forever.dadamda.dto.board;
+
+import com.forever.dadamda.entity.board.Board;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetSharedBoardTitleResponse {
+    private String title;
+
+    public static GetSharedBoardTitleResponse of(Board board) {
+        return GetSharedBoardTitleResponse.builder()
+                .title(board.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -8,6 +8,7 @@ import com.forever.dadamda.dto.board.GetBoardContentsResponse;
 import com.forever.dadamda.dto.board.GetBoardDetailResponse;
 import com.forever.dadamda.dto.board.GetBoardResponse;
 import com.forever.dadamda.dto.board.GetSharedBoardContentsResponse;
+import com.forever.dadamda.dto.board.GetSharedBoardTitleResponse;
 import com.forever.dadamda.dto.board.UpdateBoardContentsRequest;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
 import com.forever.dadamda.entity.board.Board;
@@ -148,6 +149,13 @@ public class BoardService {
     public GetSharedBoardContentsResponse getSharedBoardContents(UUID boardUUID) {
         return boardRepository.findByUuidAndDeletedDateIsNullAndIsSharedIsTrue(boardUUID)
                 .map(GetSharedBoardContentsResponse::of)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
+    }
+
+    @Transactional(readOnly = true)
+    public GetSharedBoardTitleResponse getSharedBoardTitle(UUID boardUUID) {
+        return boardRepository.findByUuidAndDeletedDateIsNullAndIsSharedIsTrue(boardUUID)
+                .map(GetSharedBoardTitleResponse::of)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
     }
 }

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -389,7 +389,7 @@ public class BoardControllerTest {
     public void should_it_returns_NF005_error_if_isShared_is_false_When_getting_shared_board()
             throws Exception {
         // 공유된 보드의 컨텐츠를 조회할때, isShared가 false이면 NF005 에러를 반환하는지 확인
-        mockMvc.perform(get("/ov1/share/boards/{boardUUID}", board2UUID)
+        mockMvc.perform(get("/ov1/share/boards/contents/{boardUUID}", board2UUID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-AUTH-TOKEN", "aaaaaaa")
                 )
@@ -403,12 +403,12 @@ public class BoardControllerTest {
     public void should_it_returns_contents_successfully_if_isShared_is_true_When_getting_shared_board()
             throws Exception {
         // 공유된 보드의 컨텐츠를 조회할때, isShared가 true이면 컨텐츠를 성공적으로 조회한다.
-        mockMvc.perform(get("/ov1/share/boards/{boardUUID}", board3UUID)
+        mockMvc.perform(get("/ov1/share/boards/contents/{boardUUID}", board3UUID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-AUTH-TOKEN", "aaaaaaa")
                 )
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.contents").value("test contents3"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").value("board3"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").doesNotExist());
     }
 }

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -411,4 +411,17 @@ public class BoardControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.contents").value("test contents3"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").doesNotExist());
     }
+
+    @Test
+    public void should_it_returns_title_successfully_if_isShared_is_true_When_getting_shared_board_title()
+            throws Exception {
+        // 공유된 보드의 타이틀을 조회할때, isShared가 true이면 타이틀을 성공적으로 조회한다.
+        mockMvc.perform(get("/ov1/share/boards/title/{boardUUID}", board3UUID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.contents").doesNotExist())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").value("board3"));
+    }
 }


### PR DESCRIPTION
## 개요
- DAD-1038

## 작업사항
- 공유된 보드 컨텐츠 조회, 타이틀 조회 API 분리
- 공유된 보드 컨텐츠 조회 API 구현
- 공유 보드 타이틀 조회 API 구현