### PR TITLE
[DAD-1047] feat: oauth2 로그인시, 쿠키에 redirect_uri 추가 

### DIFF
--- a/src/main/java/com/forever/dadamda/config/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/forever/dadamda/config/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,6 +1,7 @@
 package com.forever.dadamda.config.oauth;
 
 import com.forever.dadamda.config.oauth.util.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
     public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
     private static final int cookieExpireSeconds = 180;
 
     @Override
@@ -24,10 +26,15 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
         if (authorizationRequest == null) {
             CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
             return;
         }
 
         CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
     }
 
     @Override
@@ -37,5 +44,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
     public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
         CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
     }
 }

--- a/src/main/java/com/forever/dadamda/config/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/forever/dadamda/config/oauth/handler/OAuth2SuccessHandler.java
@@ -1,10 +1,15 @@
 package com.forever.dadamda.config.oauth.handler;
 
+import static com.forever.dadamda.config.oauth.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
 import com.forever.dadamda.config.oauth.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.forever.dadamda.config.oauth.util.CookieUtils;
 import com.forever.dadamda.service.TokenService;
 import java.io.IOException;
 import java.util.Map;
 
+import java.util.Optional;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +39,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
+
+        String targetUrl = redirectUri.orElse(LOGIN_REDIRECT_URL);
 
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
@@ -45,7 +54,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String token = tokenService.generateToken(email, "USER");
 
-        return LOGIN_REDIRECT_URL+token;
+        return targetUrl+token;
     }
 
     protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {


### PR DESCRIPTION
## 개요
- DAD-1047

## 작업사항
- oauth2 로그인시, 쿠키에 redirect_uri 추가 및 삭제 로직 추가
- oauth2 로그인시, redirect_uri로 이동하는 로직 추가

## 참고 자료 
- https://datamoney.tistory.com/336

## 추가한 이유
- 이전에는 redirect_uri가 고정적으로 정해져 있었으나, 보드 공유 페이지에서 "내 보드에 담기"라는 기능을 추가하면 사용자가 회원이 아닌 경우 회원가입을 하고 나서 다시 보드 공유 페이지로 이동해야 하기 때문에 redirect_uri가 변하기 때문에 쿠키에 redirect_uri를 저장하는 로직을 추가하였습니다.