### PR TITLE
[DAD-1049] feat: 공유 보드 담기 기능 구현

### DIFF
--- a/src/main/java/com/forever/dadamda/controller/BoardController.java
+++ b/src/main/java/com/forever/dadamda/controller/BoardController.java
@@ -170,6 +170,19 @@ public class BoardController {
         return ApiResponse.success();
     }
 
+    @Operation(summary = "공유 보드 담기", description = "공유된 보드를 내 보드로 가져옵니다.")
+    @PostMapping("/v1/own/sharedBoards/{boardUUID}")
+    public ApiResponse<String> ownSharedBoard(
+            @PathVariable @NotNull @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                    message = "UUID가 올바르지 않습니다.") String boardUUID,
+            Authentication authentication) {
+
+        String email = authentication.getName();
+        boardService.ownSharedBoard(email, UUID.fromString(boardUUID));
+
+        return ApiResponse.success();
+    }
+
     @Operation(summary = "공유된 보드 컨텐츠 조회", description = "공유된 보드 컨텐츠를 조회합니다.")
     @GetMapping("/ov1/share/boards/contents/{boardUUID}")
     public ApiResponse<GetSharedBoardContentsResponse> getSharedBoardContents(

--- a/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
@@ -32,6 +32,7 @@ public class CreateBoardRequest {
                 .description(description)
                 .tag(TAG.from(tag))
                 .uuid(uuid)
+                .authorshipUser(user)
                 .isPublic(isPublic)
                 .build();
     }

--- a/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
+++ b/src/main/java/com/forever/dadamda/dto/board/CreateBoardRequest.java
@@ -25,7 +25,7 @@ public class CreateBoardRequest {
     @NotBlank(message = "태그를 입력해주세요.")
     private String tag;
 
-    public Board toEntity(User user, UUID uuid, boolean isPublic) {
+    public Board toEntity(User user, UUID uuid) {
         return Board.builder()
                 .user(user)
                 .title(title)
@@ -33,7 +33,6 @@ public class CreateBoardRequest {
                 .tag(TAG.from(tag))
                 .uuid(uuid)
                 .authorshipUser(user)
-                .isPublic(isPublic)
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/entity/board/Board.java
+++ b/src/main/java/com/forever/dadamda/entity/board/Board.java
@@ -66,9 +66,13 @@ public class Board extends BaseTimeEntity {
     @ColumnDefault("0")
     private Long shareCnt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "authorship_id", nullable = false)
+    private User authorshipUser;
+
     @Builder
     Board(User user, String title, TAG tag, UUID uuid, String description, boolean isPublic,
-            LocalDateTime fixedDate) {
+            LocalDateTime fixedDate, User authorshipUser) {
         this.user = user;
         this.title = title;
         this.tag = tag;
@@ -76,6 +80,7 @@ public class Board extends BaseTimeEntity {
         this.description = description;
         this.isPublic = isPublic;
         this.fixedDate = fixedDate;
+        this.authorshipUser = authorshipUser;
     }
 
     public void updateFixedDate(LocalDateTime fixedDate) {

--- a/src/main/java/com/forever/dadamda/entity/board/Board.java
+++ b/src/main/java/com/forever/dadamda/entity/board/Board.java
@@ -72,7 +72,7 @@ public class Board extends BaseTimeEntity {
 
     @Builder
     Board(User user, String title, TAG tag, UUID uuid, String description,
-            LocalDateTime fixedDate, User authorshipUser) {
+            LocalDateTime fixedDate, User authorshipUser, String contents) {
         this.user = user;
         this.title = title;
         this.tag = tag;
@@ -80,6 +80,7 @@ public class Board extends BaseTimeEntity {
         this.description = description;
         this.fixedDate = fixedDate;
         this.authorshipUser = authorshipUser;
+        this.contents = contents;
     }
 
     public void updateFixedDate(LocalDateTime fixedDate) {

--- a/src/main/java/com/forever/dadamda/entity/board/Board.java
+++ b/src/main/java/com/forever/dadamda/entity/board/Board.java
@@ -40,7 +40,7 @@ public class Board extends BaseTimeEntity {
     @Column(length = 100, nullable = false)
     private String title;
 
-    @Column(columnDefinition = "boolean", nullable = false)
+    @Column(columnDefinition = "boolean default false", nullable = false)
     private boolean isPublic;
 
     @Column(columnDefinition = "boolean default false", nullable = false)
@@ -71,14 +71,13 @@ public class Board extends BaseTimeEntity {
     private User authorshipUser;
 
     @Builder
-    Board(User user, String title, TAG tag, UUID uuid, String description, boolean isPublic,
+    Board(User user, String title, TAG tag, UUID uuid, String description,
             LocalDateTime fixedDate, User authorshipUser) {
         this.user = user;
         this.title = title;
         this.tag = tag;
         this.uuid = uuid;
         this.description = description;
-        this.isPublic = isPublic;
         this.fixedDate = fixedDate;
         this.authorshipUser = authorshipUser;
     }

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -158,4 +158,25 @@ public class BoardService {
                 .map(GetSharedBoardTitleResponse::of)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
     }
+
+
+    @Transactional
+    public void ownSharedBoard(String email, UUID boardUUID) {
+        User user = userService.validateUser(email);
+
+        Board board = boardRepository.findByUuidAndDeletedDateIsNullAndIsSharedIsTrue(boardUUID)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
+
+        Board newBoard = Board.builder()
+                .user(user)
+                .title(board.getTitle())
+                .tag(board.getTag())
+                .uuid(generateUUID())
+                .description(board.getDescription())
+                .authorshipUser(board.getAuthorshipUser())
+                .contents(board.getContents())
+                .build();
+
+        boardRepository.save(newBoard);
+    }
 }

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -35,7 +35,7 @@ public class BoardService {
     public void createBoards(String email, CreateBoardRequest createBoardRequest) {
         User user = userService.validateUser(email);
 
-        Board board = createBoardRequest.toEntity(user, generateUUID(), true);
+        Board board = createBoardRequest.toEntity(user, generateUUID());
 
         boardRepository.save(board);
     }

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -45,9 +45,6 @@ public class BoardControllerTest {
     @Autowired
     private BoardRepository boardRepository;
 
-    @Autowired
-    private UserRepository userRepository;
-
     UUID board2UUID = UUID.fromString("30373832-6566-3438-2d61-3433392d3132");
 
     UUID board1UUID = UUID.fromString("30373832-6566-3438-2d61-3433392d3131");
@@ -230,37 +227,18 @@ public class BoardControllerTest {
     public void should_the_name_fixed_date_uuid_and_tag_are_returned_successfully_When_searching_for_a_board()
             throws Exception {
         // 보드를 검색할 때, 이름, 고정된 날짜, uuid, 태그가 성공적으로 출력된다.
-        // given
-        boardRepository.deleteAll();
-
-        UUID boardUUID = generateUUID();
-        User user = userRepository.findById(1L).get();
-        Board board = Board.builder()
-                .isPublic(true)
-                .title("board10")
-                .description("test")
-                .tag(LIFE_SHOPPING)
-                .fixedDate(LocalDateTime.of(2023, 1, 30, 11, 11, 1))
-                .uuid(boardUUID)
-                .user(user)
-                .build();
-        boardRepository.save(board);
-
-        //when
-        //then
         mockMvc.perform(get("/v1/boards/search")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("X-AUTH-TOKEN", "aaaaaaa")
-                        .param("keyword", "board10")
+                        .param("keyword", "board1")
                         .param("page", "0")
                         .param("size", "10")
                 )
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("board10"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].title").value("board1"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].description").doesNotExist())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].isFixed").value("2023-01-30T11:11:01"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].uuid").value(boardUUID.toString()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].tag").value("LIFE_SHOPPING"));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].uuid").value(board1UUID.toString()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].tag").value("ENTERTAINMENT_ART"));
     }
 
     @Test

--- a/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
+++ b/src/test/java/com/forever/dadamda/controller/BoardControllerTest.java
@@ -45,6 +45,9 @@ public class BoardControllerTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     UUID board2UUID = UUID.fromString("30373832-6566-3438-2d61-3433392d3132");
 
     UUID board1UUID = UUID.fromString("30373832-6566-3438-2d61-3433392d3131");
@@ -401,5 +404,38 @@ public class BoardControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.contents").doesNotExist())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.title").value("board3"));
+    }
+
+
+    @Test
+    @WithCustomMockUser
+    public void should_it_returns_OK_if_isShared_is_true_if_owning_a_shared_board()
+            throws Exception {
+        // 공유된 보드를 내 보드에 담을 때, isShared가 true이면 타이틀을 성공 응답이 온다.
+        //given
+        boardRepository.deleteAll();
+
+        UUID boardUUID = generateUUID();
+        User user = userRepository.findById(1L).get();
+        Board board = Board.builder()
+                .title("board10")
+                .description("test")
+                .tag(LIFE_SHOPPING)
+                .fixedDate(LocalDateTime.of(2023, 1, 30, 11, 11, 1))
+                .uuid(boardUUID)
+                .user(user)
+                .authorshipUser(user)
+                .build();
+        board.updateIsShared(true);
+        boardRepository.save(board);
+
+        //when
+        //then
+        mockMvc.perform(post("/v1/own/sharedBoards/{boardUUID}", boardUUID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-AUTH-TOKEN", "aaaaaaa")
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").isEmpty());
     }
 }

--- a/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
@@ -1,6 +1,7 @@
 package com.forever.dadamda.service;
 
 import static com.forever.dadamda.entity.board.TAG.LIFE_SHOPPING;
+import static com.forever.dadamda.service.UUIDService.generateUUID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -25,6 +26,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -42,6 +44,8 @@ public class BoardServiceTest {
     private UserRepository userRepository;
 
     String existentEmail = "1234@naver.com";
+
+    String existentEmail2 = "12345@naver.com";
 
     UUID board2UUID = UUID.fromString("30373832-6566-3438-2d61-3433392d3132");
 
@@ -300,5 +304,45 @@ public class BoardServiceTest {
 
         //then
         assertThat(boardRepository.findById(1L).get().isShared()).isEqualTo(false);
+    }
+
+    @Test
+    @Transactional
+    void should_the_title_description_tag_and_content_is_the_same_uuid_is_the_different_and_owner_of_shared_board_is_same_as_authorship_of_owned_board_When_owning_a_shared_board() {
+        // 공유된 보드를 내 보드에 담을 때, 공유된 보드와 담은 보드의 타이틀, 설명, 컨텐츠, 태그는 같고, uuid와 고정된 날짜는 다르다. 그리고 공유된 보드의 소유자와 담은 보드의 원작자가 같다.
+        //given
+        boardRepository.deleteAll();
+
+        UUID boardUUID = generateUUID();
+        User user = userRepository.findById(1L).get();
+        Board SharedBoard = Board.builder()
+                .title("board10")
+                .description("test")
+                .tag(LIFE_SHOPPING)
+                .fixedDate(LocalDateTime.of(2023, 1, 30, 11, 11, 1))
+                .uuid(boardUUID)
+                .user(user)
+                .authorshipUser(user)
+                .build();
+        SharedBoard.updateIsShared(true);
+        boardRepository.save(SharedBoard);
+
+        //when
+        boardService.ownSharedBoard(existentEmail2, boardUUID);
+
+        //then
+        User user2 = userRepository.findById(2L).get();
+        Board SharedBoard2 = boardRepository.findByUserAndUuidAndDeletedDateIsNull(user, boardUUID).get();
+        Board OwnSharedBoard = boardRepository.findByUserAndTitle(user2, "board10").get();
+
+        assertThat(OwnSharedBoard.getAuthorshipUser()).isEqualTo(SharedBoard2.getUser());
+        assertThat(OwnSharedBoard.isShared()).isEqualTo(false);
+        assertThat(OwnSharedBoard.getUser().getEmail()).isEqualTo(existentEmail2);
+        assertThat(OwnSharedBoard.getUuid()).isNotSameAs(SharedBoard2.getUuid());
+        assertThat(OwnSharedBoard.getContents()).isEqualTo(SharedBoard2.getContents());
+        assertThat(OwnSharedBoard.getDescription()).isEqualTo(SharedBoard2.getDescription());
+        assertThat(OwnSharedBoard.getTitle()).isEqualTo(SharedBoard2.getTitle());
+        assertThat(OwnSharedBoard.getTag()).isEqualTo(SharedBoard2.getTag());
+        assertThat(OwnSharedBoard.getFixedDate()).isNull();
     }
 }

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -3,17 +3,17 @@ INSERT INTO users (user_id, name, provider, role, email, profile_url)
 VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
 
 -- Board 데이터 삽입
-INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, is_shared, modified_date)
-VALUES (1, 1, 'board1', 'test', '0782ef48-a439-11', 0 ,'2023-01-01 11:11:01', 1, 1, '2023-01-01 11:11:01');
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, is_shared, modified_date, authorship_id)
+VALUES (1, 1, 'board1', 'test', '0782ef48-a439-11', 0 ,'2023-01-01 11:11:01', 1, 1, '2023-01-01 11:11:01', 1);
 
-INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date, contents)
-VALUES (1, 2, 'board2', 'test', '0782ef48-a439-12', 1 ,'2023-01-01 11:11:01', 1, '2023-01-02 11:11:01', '2023-01-03 11:11:01', 'test contents');
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date, contents, authorship_id)
+VALUES (1, 2, 'board2', 'test', '0782ef48-a439-12', 1 ,'2023-01-01 11:11:01', 1, '2023-01-02 11:11:01', '2023-01-03 11:11:01', 'test contents', 1);
 
-INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, is_shared, modified_date, contents)
-VALUES (1, 3, 'board3', 'test', '0782ef48-a439-13', 0 ,'2023-01-01 11:11:01', 1, 1, '2023-01-03 11:11:01', 'test contents3');
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, is_shared, modified_date, contents, authorship_id)
+VALUES (1, 3, 'board3', 'test', '0782ef48-a439-13', 0 ,'2023-01-01 11:11:01', 1, 1, '2023-01-03 11:11:01', 'test contents3', 1);
 
-INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date)
-VALUES (1, 4, 'board4', 'test', '0782ef48-a439-14', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01');
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date, authorship_id)
+VALUES (1, 4, 'board4', 'test', '0782ef48-a439-14', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01', 1);
 
-INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, deleted_date)
-VALUES (1, 5, 'board5', 'test', '0782ef48-a439-15', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01');
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, deleted_date, authorship_id)
+VALUES (1, 5, 'board5', 'test', '0782ef48-a439-15', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01', 1);

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -2,6 +2,9 @@
 INSERT INTO users (user_id, name, provider, role, email, profile_url)
 VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
 
+INSERT INTO users (user_id, name, provider, role, email, profile_url)
+VALUES (2, 'coco', 0, 'USER', '12345@naver.com', 'https://www.naver.com');
+
 -- Board 데이터 삽입
 INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, is_shared, modified_date, authorship_id)
 VALUES (1, 1, 'board1', 'test', '0782ef48-a439-11', 0 ,'2023-01-01 11:11:01', 1, 1, '2023-01-01 11:11:01', 1);


### PR DESCRIPTION
## 개요
- DAD-1049

## 작업사항
- 보드의 원작자(authorship) 속성 추가
- 보드 생성시 원작자 설정 추가
- 보드 트랜딩 게시 여부의 기본값을 false로 설정
- 공유 보드 담기 기능 구현 + 테스트 코드 작성
- 기능 추가로 인한 테스트 코드 오류 수정