### PR TITLE
[DAD-1051] feat: 사용자 랜덤 닉네임, uuid 설정 추가

### DIFF
--- a/src/main/java/com/forever/dadamda/config/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/forever/dadamda/config/oauth/CustomOAuth2UserService.java
@@ -4,6 +4,7 @@ import static com.forever.dadamda.service.RandomService.adjectivesLength;
 import static com.forever.dadamda.service.RandomService.animalsLength;
 import static com.forever.dadamda.service.RandomService.generateRandomNickname;
 import static com.forever.dadamda.service.RandomService.numberLength;
+import static com.forever.dadamda.service.UUIDService.generateUUID;
 
 import com.forever.dadamda.dto.user.OAuthAttributes;
 import com.forever.dadamda.entity.user.User;
@@ -56,7 +57,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         User user = userRepository.findByEmailAndDeletedDateIsNull(attributes.getEmail())
                 .map(entity -> entity.update(attributes.getName(), attributes.getProfileUrl()))
-                .orElseGet(() -> attributes.toEntity(getNewNickname()));
+                .orElseGet(() -> attributes.toEntity(getNewNickname(), generateUUID()));
 
         return userRepository.save(user);
     }

--- a/src/main/java/com/forever/dadamda/dto/user/OAuthAttributes.java
+++ b/src/main/java/com/forever/dadamda/dto/user/OAuthAttributes.java
@@ -68,13 +68,14 @@ public class OAuthAttributes {
                 .build();
     }
 
-    public User toEntity() {
+    public User toEntity(String nickname) {
         return User.builder()
                 .name(name)
                 .email(email)
                 .profileUrl(profileUrl)
                 .provider(provider)
                 .role(Role.USER)
+                .nickname(nickname)
                 .build();
     }
 }

--- a/src/main/java/com/forever/dadamda/dto/user/OAuthAttributes.java
+++ b/src/main/java/com/forever/dadamda/dto/user/OAuthAttributes.java
@@ -3,6 +3,7 @@ package com.forever.dadamda.dto.user;
 import com.forever.dadamda.entity.user.Provider;
 import com.forever.dadamda.entity.user.Role;
 import com.forever.dadamda.entity.user.User;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -68,13 +69,14 @@ public class OAuthAttributes {
                 .build();
     }
 
-    public User toEntity(String nickname) {
+    public User toEntity(String nickname, UUID uuid) {
         return User.builder()
                 .name(name)
                 .email(email)
                 .profileUrl(profileUrl)
                 .provider(provider)
                 .role(Role.USER)
+                .uuid(uuid)
                 .nickname(nickname)
                 .build();
     }

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -33,7 +33,7 @@ public class User extends BaseTimeEntity implements Serializable {
     @Column(length = 320, nullable = false)
     private String email;
 
-    @Column(length = 2083, nullable = false)
+    @Column(length = 2083)
     private String profileUrl;
 
     @Column(nullable = false)

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -31,7 +31,7 @@ public class User extends BaseTimeEntity implements Serializable {
     @Column(length = 100, nullable = false)
     private String name;
 
-    @Column(length = 320, nullable = false, unique = true)
+    @Column(length = 320, nullable = false)
     private String email;
 
     @Column(length = 2083)

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -5,6 +5,7 @@ import com.forever.dadamda.entity.scrap.Scrap;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,8 +40,8 @@ public class User extends BaseTimeEntity implements Serializable {
     @Column(nullable = false)
     private Provider provider;
 
-    //@Column(length = 36, nullable = false)
-    private String uuid;
+    @Column(columnDefinition = "BINARY(16)", nullable = false, unique = true)
+    private UUID uuid;
 
     @Column(length = 10, nullable = false, unique = true)
     private String nickname;
@@ -50,13 +51,15 @@ public class User extends BaseTimeEntity implements Serializable {
     private Role role;
 
     @Builder
-    public User(String name, String email, String profileUrl, Provider provider, Role role, String nickname) {
+    public User(String name, String email, String profileUrl, Provider provider, Role role,
+            String nickname, UUID uuid) {
         this.name = name;
         this.email = email;
         this.profileUrl = profileUrl;
         this.provider = provider;
         this.role = role;
         this.nickname = nickname;
+        this.uuid = uuid;
     }
 
     public User update(String name, String profileUrl) {

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -42,17 +42,21 @@ public class User extends BaseTimeEntity implements Serializable {
     //@Column(length = 36, nullable = false)
     private String uuid;
 
+    @Column(length = 10, nullable = false, unique = true)
+    private String nickname;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
 
     @Builder
-    public User(String name, String email, String profileUrl, Provider provider, Role role) {
+    public User(String name, String email, String profileUrl, Provider provider, Role role, String nickname) {
         this.name = name;
         this.email = email;
         this.profileUrl = profileUrl;
         this.provider = provider;
         this.role = role;
+        this.nickname = nickname;
     }
 
     public User update(String name, String profileUrl) {

--- a/src/main/java/com/forever/dadamda/entity/user/User.java
+++ b/src/main/java/com/forever/dadamda/entity/user/User.java
@@ -30,7 +30,7 @@ public class User extends BaseTimeEntity implements Serializable {
     @Column(length = 100, nullable = false)
     private String name;
 
-    @Column(length = 320, nullable = false)
+    @Column(length = 320, nullable = false, unique = true)
     private String email;
 
     @Column(length = 2083)

--- a/src/main/java/com/forever/dadamda/repository/UserRepository.java
+++ b/src/main/java/com/forever/dadamda/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndDeletedDateIsNull(String email);
+
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/forever/dadamda/service/RandomService.java
+++ b/src/main/java/com/forever/dadamda/service/RandomService.java
@@ -6,13 +6,13 @@ public class RandomService {
     public static final int animalsLength = 30;
     public static final int numberLength = 1000;
 
-    private static final String[] adjectives = {
+    public static final String[] adjectives = {
             "졸린", "귀여운", "용감한", "화난", "흥겨운", "우등생", "달리는", "거대한", "심심한", "더운",
             "추운", "시원한", "쿨한", "슬픈", "예민한", "편안한", "행복한", "즐거운", "아늑한", "빛나는",
             "명량한", "야생의", "똑똑한", "성공한", "출세한", "현명한", "성실한", "정직한", "야심찬", "엉뚱한"
     };
 
-    private static final String[] animals = {
+    public static final String[] animals = {
             "쿼카", "악어", "기린", "코끼리", "오리", "너구리", "호랑이", "강아지", "토끼", "사자",
             "원숭이", "고양이", "여우", "수달", "곰", "부엉이", "뱀", "하마", "고래", "판다",
             "사슴", "염소", "다람쥐", "알파카", "낙타", "두더지", "앵무새", "얼룩말", "해달", "코뿔소"

--- a/src/main/java/com/forever/dadamda/service/RandomService.java
+++ b/src/main/java/com/forever/dadamda/service/RandomService.java
@@ -1,0 +1,27 @@
+package com.forever.dadamda.service;
+
+public class RandomService {
+
+    public static final int adjectivesLength = 30;
+    public static final int animalsLength = 30;
+    public static final int numberLength = 1000;
+
+    private static final String[] adjectives = {
+            "졸린", "귀여운", "용감한", "화난", "흥겨운", "우등생", "달리는", "거대한", "심심한", "더운",
+            "추운", "시원한", "쿨한", "슬픈", "예민한", "편안한", "행복한", "즐거운", "아늑한", "빛나는",
+            "명량한", "야생의", "똑똑한", "성공한", "출세한", "현명한", "성실한", "정직한", "야심찬", "엉뚱한"
+    };
+
+    private static final String[] animals = {
+            "쿼카", "악어", "기린", "코끼리", "오리", "너구리", "호랑이", "강아지", "토끼", "사자",
+            "원숭이", "고양이", "여우", "수달", "곰", "부엉이", "뱀", "하마", "고래", "판다",
+            "사슴", "염소", "다람쥐", "알파카", "낙타", "두더지", "앵무새", "얼룩말", "해달", "코뿔소"
+    };
+
+    public static String generateRandomNickname() {
+        String adjective = adjectives[(int) (Math.random() * adjectivesLength)];
+        String animal = animals[(int) (Math.random() * animalsLength)];
+        String number = String.valueOf((int) (Math.random() * numberLength));
+        return adjective + animal + number;
+    }
+}

--- a/src/test/java/com/forever/dadamda/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,68 @@
+package com.forever.dadamda.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.forever.dadamda.config.oauth.CustomOAuth2UserService;
+import com.forever.dadamda.dto.user.OAuthAttributes;
+import com.forever.dadamda.entity.user.Provider;
+import com.forever.dadamda.entity.user.Role;
+import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = "/truncate.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+public class CustomOAuth2UserServiceTest {
+
+    @Autowired
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    String email = "1234@gmail.com";
+
+    @Test
+    void should_a_new_user_with_new_nickname_is_created_When_no_user_sings_up_with_that_email() {
+        // 해당 이메일로 가입한 유저가 없을 때, 닉네임이 생성된 새로운 유저가 생성된다.
+        //given
+        OAuthAttributes attributes = OAuthAttributes.builder().name("test").email(email)
+                .provider(Provider.GOOGLE).build();
+
+        //when
+        customOAuth2UserService.saveOrUpdate(attributes);
+
+        //then
+        User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();
+        assertThat(user).isNotNull();
+        assertThat(user.getNickname()).isNotNull();
+        assertThat(user.getModifiedDate().toString()).isEqualTo(user.getCreatedDate().toString());
+    }
+
+    @Test
+    void should_the_existing_nickname_is_not_changed_but_only_the_name_is_changed_When_logging_in_by_changing_the_user_name() {
+        //  유저의 이름을 변경하여 로그인할때, 기존의 닉네임은 변경되지 않고, 이름만 변경된다.
+        //given
+        User savedUser = User.builder().name("test").email(email).nickname("test")
+                .provider(Provider.GOOGLE).role(Role.USER).build();
+        userRepository.save(savedUser);
+
+        OAuthAttributes attributes = OAuthAttributes.builder().name("changedName")
+                .email(email).provider(Provider.GOOGLE).build();
+
+        customOAuth2UserService.saveOrUpdate(attributes);
+
+        //then
+        User user = userRepository.findByEmailAndDeletedDateIsNull(email).get();
+        assertThat(user).isNotNull();
+        assertThat(user.getNickname()).isEqualTo("test");
+        assertThat(user.getName()).isEqualTo("changedName");
+        assertThat(user.getModifiedDate()).isAfter(user.getCreatedDate());
+    }
+}

--- a/src/test/java/com/forever/dadamda/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/CustomOAuth2UserServiceTest.java
@@ -8,6 +8,7 @@ import com.forever.dadamda.entity.user.Provider;
 import com.forever.dadamda.entity.user.Role;
 import com.forever.dadamda.entity.user.User;
 import com.forever.dadamda.repository.UserRepository;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,11 +47,12 @@ public class CustomOAuth2UserServiceTest {
     }
 
     @Test
-    void should_the_existing_nickname_is_not_changed_but_only_the_name_is_changed_When_logging_in_by_changing_the_user_name() {
+    void should_the_existing_nickname_and_uuid_is_not_changed_but_only_the_name_is_changed_When_logging_in_by_changing_the_user_name() {
         //  유저의 이름을 변경하여 로그인할때, 기존의 닉네임은 변경되지 않고, 이름만 변경된다.
         //given
+        UUID uuid = UUIDService.generateUUID();
         User savedUser = User.builder().name("test").email(email).nickname("test")
-                .provider(Provider.GOOGLE).role(Role.USER).build();
+                .provider(Provider.GOOGLE).role(Role.USER).uuid(uuid).build();
         userRepository.save(savedUser);
 
         OAuthAttributes attributes = OAuthAttributes.builder().name("changedName")
@@ -64,5 +66,6 @@ public class CustomOAuth2UserServiceTest {
         assertThat(user.getNickname()).isEqualTo("test");
         assertThat(user.getName()).isEqualTo("changedName");
         assertThat(user.getModifiedDate()).isAfter(user.getCreatedDate());
+        assertThat(user.getUuid()).isEqualTo(uuid);
     }
 }

--- a/src/test/java/com/forever/dadamda/service/RandomServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/RandomServiceTest.java
@@ -1,0 +1,79 @@
+package com.forever.dadamda.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class RandomServiceTest {
+
+    int maxWordLength = 3;
+
+    @Test
+    void should_adjectives_array_have_no_duplicate_values_and_length_equal_to_the_adjectivesLength() {
+        // adjectives 배열은 중복된 값이 없어야 하며, 길이가 adjectivesLength와 같아야 한다.
+        String[] adjectives = RandomService.adjectives;
+        Set<String> adjectiveSet = new HashSet<>(List.of(adjectives));
+
+        assertThat(adjectiveSet.size()).isEqualTo(adjectives.length);
+        assertThat(adjectiveSet.size()).isEqualTo(RandomService.adjectivesLength);
+    }
+
+    @Test
+    void should_animals_array_have_no_duplicate_values_and_length_equal_to_the_animalsLength() {
+        // animals 배열은 중복된 값이 없어야 하며, 길이가 animalsLength와 같아야 한다.
+        //given
+        //when
+        String[] animals = RandomService.animals;
+        Set<String> animalSet = new HashSet<>(List.of(animals));
+
+        //then
+        assertThat(animalSet.size()).isEqualTo(animals.length);
+        assertThat(animalSet.size()).isEqualTo(RandomService.animalsLength);
+    }
+
+    @Test
+    void should_the_maximum_string_length_of_the_adjectives_array_is_maxWordLength() {
+        // adjectives 배열의 문자열 최대 길이는 3이다.
+        String[] adjectives = RandomService.adjectives;
+
+        int adjectiveMaxLength = 0;
+
+        for(String adjective : adjectives) {
+            if(adjectiveMaxLength < adjective.length()) {
+                adjectiveMaxLength = adjective.length();
+            }
+        }
+
+        assertThat(adjectiveMaxLength).isLessThanOrEqualTo(maxWordLength);
+    }
+
+    @Test
+    void should_the_maximum_string_length_of_the_animals_array_is_maxWordLength() {
+        // animals 배열의 문자열 최대 길이는 3이다.
+        String[] animals = RandomService.adjectives;
+
+        int animalMaxLength = 0;
+
+        for(String animal : animals) {
+            if(animalMaxLength < animal.length()) {
+                animalMaxLength = animal.length();
+            }
+        }
+
+        assertThat(animalMaxLength).isLessThanOrEqualTo(maxWordLength);
+    }
+
+    @Test
+    void should_the_maximum_length_of_the_nickname_is_10_when_generating_a_random_nickname() {
+        // 랜덤 닉네임을 생성할때, 닉네임의 최대 길이는 10이다.
+        //given
+        //when
+        String nickname = RandomService.generateRandomNickname();
+
+        //then
+        assertThat(nickname.length()).isLessThanOrEqualTo(10);
+    }
+}

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
 
 INSERT INTO users (user_id, name, provider, role, email, profile_url)
 VALUES (2, 'coco', 0, 'USER', '12345@naver.com', 'https://www.naver.com');

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname, uuid)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1', '0782ef48-a439-01');
 
 INSERT INTO users (user_id, name, provider, role, email, profile_url)
 VALUES (2, 'coco', 0, 'USER', '12345@naver.com', 'https://www.naver.com');

--- a/src/test/resources/other-setup.sql
+++ b/src/test/resources/other-setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
 
 -- Other 데이터 삽입
 INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type, created_date)

--- a/src/test/resources/other-setup.sql
+++ b/src/test/resources/other-setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname, uuid)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1', '0782ef48-a439-01');
 
 -- Other 데이터 삽입
 INSERT INTO scrap (user_id, scrap_id, page_url, title, description, d_type, created_date)

--- a/src/test/resources/place-setup.sql
+++ b/src/test/resources/place-setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname, uuid)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1', '0782ef48-a439-01');
 
 -- Place 데이터 삽입
 INSERT INTO scrap (user_id, scrap_id, page_url, latitude, longitude, title, d_type, created_date)

--- a/src/test/resources/place-setup.sql
+++ b/src/test/resources/place-setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
 
 -- Place 데이터 삽입
 INSERT INTO scrap (user_id, scrap_id, page_url, latitude, longitude, title, d_type, created_date)

--- a/src/test/resources/setup.sql
+++ b/src/test/resources/setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname, uuid)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1', '0782ef48-a439-01');
 
 -- Product 데이터 삽입
 INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, created_date)

--- a/src/test/resources/setup.sql
+++ b/src/test/resources/setup.sql
@@ -1,6 +1,6 @@
 -- User 데이터 삽입
-INSERT INTO users (user_id, name, provider, role, email, profile_url)
-VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com');
+INSERT INTO users (user_id, name, provider, role, email, profile_url, nickname)
+VALUES (1, 'koko', 0, 'USER', '1234@naver.com', 'https://www.naver.com', '귀여운해달1');
 
 -- Product 데이터 삽입
 INSERT INTO scrap (user_id, scrap_id, page_url, title, description, site_name, d_type, created_date)


### PR DESCRIPTION
## 개요
- DAD-1051

## 작업사항
- 사용자 랜덤 닉네임, uuid 설정 추가
- 랜덤 닉네임 서비스 로직 추가 + 테스트 코드 작성
- 프로필 이미지 url을 null도 허용