### PR TITLE
[DAD-1171] feat: 복제 보드면 트렌딩에 게시할 수 없도록 구현

### DIFF
--- a/src/main/java/com/forever/dadamda/dto/ErrorCode.java
+++ b/src/main/java/com/forever/dadamda/dto/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_DUPLICATED_SCRAP("BR002","이미 저장된 URL입니다."),
     INVALID_DUPLICATED_NICKNAME("BR003", "이미 사용중인 닉네임입니다."),
     INVALID_HEART("BR004", "좋아요를 누르지 않은 글입니다."),
+    INVALID_AUTHENTICATION_TO_PUBLISH("BR005", "게시 권한이 없습니다."),
 
     /**
      * 404 Not Found (존재하지 않는 리소스)

--- a/src/main/java/com/forever/dadamda/service/BoardService.java
+++ b/src/main/java/com/forever/dadamda/service/BoardService.java
@@ -16,6 +16,7 @@ import com.forever.dadamda.dto.board.UpdateBoardContentsRequest;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.InvalidException;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.service.user.UserService;
@@ -217,6 +218,10 @@ public class BoardService {
 
         Board board = boardRepository.findByUserAndUuidAndDeletedDateIsNull(user, boardUUID)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXISTS_BOARD));
+
+        if(board.getOriginalBoardId() != null) {
+            throw new InvalidException(ErrorCode.INVALID_AUTHENTICATION_TO_PUBLISH);
+        }
 
         board.updateIsPublic(!board.isPublic());
     }

--- a/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
+++ b/src/test/java/com/forever/dadamda/service/BoardServiceTest.java
@@ -12,6 +12,7 @@ import com.forever.dadamda.dto.board.UpdateBoardContentsRequest;
 import com.forever.dadamda.dto.board.UpdateBoardRequest;
 import com.forever.dadamda.entity.board.Board;
 import com.forever.dadamda.entity.user.User;
+import com.forever.dadamda.exception.InvalidException;
 import com.forever.dadamda.exception.NotFoundException;
 import com.forever.dadamda.repository.board.BoardRepository;
 import com.forever.dadamda.repository.UserRepository;
@@ -381,5 +382,17 @@ public class BoardServiceTest {
 
         assertThat(SharedBoard2.getOriginalBoardId()).isEqualTo(2L);
         assertThat(OwnSharedBoard.getOriginalBoardId()).isEqualTo(SharedBoard2.getOriginalBoardId());
+    }
+
+    @Test
+    @Transactional
+    void should_the_copy_board_is_denied_when_publish(){
+        // 복제한 보드는 공개 시 원작자인지 확인하고 아니라면 예외 처리한다.
+        //given
+        //when
+        //then
+
+        assertThatThrownBy(() -> boardService.updateBoardIsPublic(existentEmail, board2UUID))
+                .isInstanceOf(InvalidException.class);
     }
 }

--- a/src/test/resources/board-setup.sql
+++ b/src/test/resources/board-setup.sql
@@ -9,8 +9,8 @@ VALUES (2, 'coco', 0, 'USER', '12345@naver.com', 'https://www.naver.com', 'ê·€ì—
 INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, is_shared, modified_date, thumbnail_url, heart_cnt, view_cnt, share_cnt)
 VALUES (1, 1, 'board1', 'test', '0782ef48-a439-11', 0 ,'2023-01-01 11:11:01', 1, 1, '2023-01-01 11:11:01', 'board1 thumbnail url', 10, 11, 12);
 
-INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date, contents, heart_cnt, view_cnt, share_cnt)
-VALUES (1, 2, 'board2', 'test', '0782ef48-a439-12', 1 ,'2023-01-01 11:11:01', 0, '2023-01-02 11:11:01', '2023-01-03 11:11:01', 'test contents', 0, 0, 0);
+INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, fixed_date, contents, heart_cnt, view_cnt, share_cnt, original_board_id)
+VALUES (1, 2, 'board2', 'test', '0782ef48-a439-12', 1 ,'2023-01-01 11:11:01', 0, '2023-01-02 11:11:01', '2023-01-03 11:11:01', 'test contents', 0, 0, 0, 1);
 
 INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, is_shared, modified_date, contents, heart_cnt, view_cnt, share_cnt)
 VALUES (1, 3, 'board3', 'test', '0782ef48-a439-13', 1 ,'2023-01-01 11:11:01', 1, 1, '2023-01-03 11:11:01', 'test contents3', 10, 11, 13);
@@ -20,3 +20,5 @@ VALUES (1, 4, 'board4', 'test', '0782ef48-a439-14', 2 ,'2023-01-01 11:11:01', 1,
 
 INSERT INTO board (user_id, board_id, title, description, uuid, tag, created_date, is_public, modified_date, deleted_date, heart_cnt, view_cnt, share_cnt)
 VALUES (1, 5, 'board5', 'test', '0782ef48-a439-15', 0 ,'2023-01-01 11:11:01', 1, '2023-01-04 11:11:01', '2023-01-04 11:11:01', 6, 11, 12);
+
+


### PR DESCRIPTION
## 개요
- DAD-1171

## 작업사항
- 복제 보드면 트렌딩에 게시할 수 없도록 구현
- 관련 테스트 코드 작성